### PR TITLE
Add auto-save for settings and config change events

### DIFF
--- a/src/ShareX.Avalonia.Core/Models/TaskSettings.cs
+++ b/src/ShareX.Avalonia.Core/Models/TaskSettings.cs
@@ -230,8 +230,8 @@ public class TaskSettingsUpload
 
     public bool UseCustomTimeZone = false;
     public TimeZoneInfo CustomTimeZone = TimeZoneInfo.Utc;
-    public string NameFormatPattern = "%y-%mo-%d_%h-%mi-%s";
-    public string NameFormatPatternActiveWindow = "%pn_%ra{10}";
+    public string NameFormatPattern = "%y%mo%dT%h%mi_%ra{10}";
+    public string NameFormatPatternActiveWindow = "%y%mo%dT%h%mi_%pn_%ra{10}";
     public bool FileUploadUseNamePattern = false;
     public bool FileUploadReplaceProblematicCharacters = false;
     public bool URLRegexReplace = false;

--- a/src/ShareX.Avalonia.UI/ViewModels/DestinationSettingsViewModel.cs
+++ b/src/ShareX.Avalonia.UI/ViewModels/DestinationSettingsViewModel.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using ShareX.Ava.Core;
 using ShareX.Ava.Uploaders.PluginSystem;
 using System.Collections.ObjectModel;
 
@@ -47,11 +48,20 @@ public partial class DestinationSettingsViewModel : ViewModelBase
         foreach (var p in allProviders)
         {
             Common.DebugHelper.WriteLine($"[DestinationSettings]   - {p.Name} ({p.ProviderId})");
+            
+            // Subscribe to config change events from each provider
+            p.ConfigChanged += Provider_ConfigChanged;
         }
         
         Common.DebugHelper.WriteLine("[DestinationSettings] ========================================");
         
         LoadCategories();
+    }
+
+    private void Provider_ConfigChanged(object? sender, EventArgs e)
+    {
+        // Save uploaders config when any provider's configuration changes
+        SettingManager.SaveUploadersConfigAsync();
     }
 
     private void LoadCategories()

--- a/src/ShareX.Avalonia.UI/ViewModels/HotkeySettingsViewModel.cs
+++ b/src/ShareX.Avalonia.UI/ViewModels/HotkeySettingsViewModel.cs
@@ -53,6 +53,20 @@ public partial class HotkeySettingsViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// Sync manager's hotkeys to config and save to disk
+    /// </summary>
+    private void SaveHotkeys()
+    {
+        if (_manager != null)
+        {
+            // Sync to config
+            SettingManager.HotkeysConfig.Hotkeys = _manager.Hotkeys;
+            // Save to disk
+            SettingManager.SaveHotkeysConfigAsync();
+        }
+    }
+
     [RelayCommand]
     private void Add()
     {
@@ -65,6 +79,7 @@ public partial class HotkeySettingsViewModel : ViewModelBase
         _manager.Hotkeys.Add(newHotkey);
         
         LoadHotkeys();
+        SaveHotkeys();
     }
 
     [RelayCommand(CanExecute = nameof(CanModifyHotkey))]
@@ -76,6 +91,7 @@ public partial class HotkeySettingsViewModel : ViewModelBase
             // Also remove from manager's list if separate
             _manager.Hotkeys.Remove(SelectedHotkey.Model);
             LoadHotkeys();
+            SaveHotkeys();
             SelectedHotkey = null;
         }
     }
@@ -97,6 +113,7 @@ public partial class HotkeySettingsViewModel : ViewModelBase
                     _manager.RegisterHotkey(SelectedHotkey.Model);
                 }
                 SelectedHotkey.Refresh();
+                SaveHotkeys();
             }
         }
     }
@@ -115,6 +132,7 @@ public partial class HotkeySettingsViewModel : ViewModelBase
             // Just add to list, user needs to change key
             _manager.Hotkeys.Add(clone);
             LoadHotkeys();
+            SaveHotkeys();
         }
     }
 
@@ -129,6 +147,7 @@ public partial class HotkeySettingsViewModel : ViewModelBase
              _manager.Hotkeys.RemoveAt(index);
              _manager.Hotkeys.Insert(index - 1, SelectedHotkey.Model);
              LoadHotkeys();
+             SaveHotkeys();
              SelectedHotkey = Hotkeys[index - 1];
          }
     }
@@ -143,6 +162,7 @@ public partial class HotkeySettingsViewModel : ViewModelBase
              _manager.Hotkeys.RemoveAt(index);
              _manager.Hotkeys.Insert(index + 1, SelectedHotkey.Model);
              LoadHotkeys();
+             SaveHotkeys();
              SelectedHotkey = Hotkeys[index + 1];
          }
     }
@@ -155,6 +175,7 @@ public partial class HotkeySettingsViewModel : ViewModelBase
             var defaults = Core.Hotkeys.HotkeyManager.GetDefaultHotkeyList();
             _manager.UpdateHotkeys(defaults);
             LoadHotkeys();
+            SaveHotkeys();
         }
     }
 

--- a/src/ShareX.Avalonia.UI/ViewModels/SettingsViewModel.cs
+++ b/src/ShareX.Avalonia.UI/ViewModels/SettingsViewModel.cs
@@ -7,6 +7,8 @@ namespace ShareX.Ava.UI.ViewModels
 {
     public partial class SettingsViewModel : ViewModelBase
     {
+        private bool _isLoading = true;
+
         [ObservableProperty]
         private string _screenshotsFolder;
 
@@ -77,6 +79,7 @@ namespace ShareX.Ava.UI.ViewModels
         {
             HotkeySettings = new HotkeySettingsViewModel();
             LoadSettings();
+            _isLoading = false;
         }
 
         private void LoadSettings()
@@ -111,6 +114,17 @@ namespace ShareX.Ava.UI.ViewModels
             URLRegexReplace = taskSettings.UploadSettings.URLRegexReplace;
             URLRegexReplacePattern = taskSettings.UploadSettings.URLRegexReplacePattern;
             URLRegexReplaceReplacement = taskSettings.UploadSettings.URLRegexReplaceReplacement;
+        }
+
+        protected override void OnPropertyChanged(System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            base.OnPropertyChanged(e);
+            
+            // Auto-save when any property changes (after initial load)
+            if (!_isLoading && e.PropertyName != nameof(HotkeySettings))
+            {
+                SaveSettings();
+            }
         }
 
         [RelayCommand]

--- a/src/ShareX.Avalonia.UI/Views/DestinationSettingsView.axaml.cs
+++ b/src/ShareX.Avalonia.UI/Views/DestinationSettingsView.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using ShareX.Ava.Core;
 
 namespace ShareX.Ava.UI.Views
 {
@@ -17,6 +18,12 @@ namespace ShareX.Ava.UI.Views
                 {
                     await vm.Initialize();
                 }
+            };
+            
+            // Save uploaders config when navigating away from this view
+            Unloaded += (s, e) =>
+            {
+                SettingManager.SaveUploadersConfigAsync();
             };
         }
 

--- a/src/ShareX.Avalonia.UI/Views/TaskSettingsView.axaml
+++ b/src/ShareX.Avalonia.UI/Views/TaskSettingsView.axaml
@@ -71,22 +71,22 @@
                                 <StackPanel Spacing="10">
                                     <Grid ColumnDefinitions="Auto, 10, *">
                                         <TextBlock Grid.Column="0" Text="Name pattern:" VerticalAlignment="Center"/>
-                                        <TextBox Grid.Column="2" Text="{Binding NameFormatPattern}"/>
+                                        <TextBox Grid.Column="2" Text="{Binding NameFormatPattern, Mode=TwoWay}"/>
                                     </Grid>
                                     <Grid ColumnDefinitions="Auto, 10, *">
                                         <TextBlock Grid.Column="0" Text="Active window name pattern:" VerticalAlignment="Center"/>
-                                        <TextBox Grid.Column="2" Text="{Binding NameFormatPatternActiveWindow}"/>
+                                        <TextBox Grid.Column="2" Text="{Binding NameFormatPatternActiveWindow, Mode=TwoWay}"/>
                                     </Grid>
                                     <CheckBox IsChecked="{Binding FileUploadUseNamePattern}" Content="Use name pattern for file uploaders"/>
                                     <CheckBox IsChecked="{Binding FileUploadReplaceProblematicCharacters}" Content="Replace potentially problematic characters"/>
                                     <CheckBox IsChecked="{Binding URLRegexReplace}" Content="Perform regex replace on URL"/>
                                     <Grid ColumnDefinitions="Auto, 10, *" IsVisible="{Binding URLRegexReplace}">
                                         <TextBlock Grid.Column="0" Text="Regex pattern:" VerticalAlignment="Center"/>
-                                        <TextBox Grid.Column="2" Text="{Binding URLRegexReplacePattern}"/>
+                                        <TextBox Grid.Column="2" Text="{Binding URLRegexReplacePattern, Mode=TwoWay}"/>
                                     </Grid>
                                     <Grid ColumnDefinitions="Auto, 10, *" IsVisible="{Binding URLRegexReplace}">
                                         <TextBlock Grid.Column="0" Text="Replacement:" VerticalAlignment="Center"/>
-                                        <TextBox Grid.Column="2" Text="{Binding URLRegexReplaceReplacement}"/>
+                                        <TextBox Grid.Column="2" Text="{Binding URLRegexReplaceReplacement, Mode=TwoWay}"/>
                                     </Grid>
                                 </StackPanel>
                             </Border>

--- a/src/ShareX.Avalonia.Uploaders/PluginSystem/IUploaderPlugin.cs
+++ b/src/ShareX.Avalonia.Uploaders/PluginSystem/IUploaderPlugin.cs
@@ -80,4 +80,10 @@ public interface IUploaderPlugin
     /// Returns default configuration instance
     /// </summary>
     object GetDefaultConfig();
+
+    /// <summary>
+    /// Event raised when the plugin's configuration has changed.
+    /// The host subscribes to this event to trigger saving UploadersConfig.
+    /// </summary>
+    event EventHandler? ConfigChanged;
 }

--- a/src/ShareX.Avalonia.Uploaders/PluginSystem/IUploaderProvider.cs
+++ b/src/ShareX.Avalonia.Uploaders/PluginSystem/IUploaderProvider.cs
@@ -93,4 +93,10 @@ public interface IUploaderProvider
     /// Returns default serialized settings JSON for the given category
     /// </summary>
     string GetDefaultSettings(UploaderCategory category);
+
+    /// <summary>
+    /// Event raised when the provider's configuration has changed.
+    /// The host subscribes to this event to trigger saving UploadersConfig.
+    /// </summary>
+    event EventHandler? ConfigChanged;
 }

--- a/src/ShareX.Avalonia.Uploaders/PluginSystem/UploaderPluginBase.cs
+++ b/src/ShareX.Avalonia.Uploaders/PluginSystem/UploaderPluginBase.cs
@@ -58,4 +58,17 @@ public abstract class UploaderPluginBase : IUploaderPlugin
     }
 
     public abstract object GetDefaultConfig();
+
+    /// <summary>
+    /// Event raised when the plugin's configuration has changed
+    /// </summary>
+    public event EventHandler? ConfigChanged;
+
+    /// <summary>
+    /// Raises the ConfigChanged event. Derived classes should call this when their config is modified.
+    /// </summary>
+    protected virtual void OnConfigChanged()
+    {
+        ConfigChanged?.Invoke(this, EventArgs.Empty);
+    }
 }

--- a/src/ShareX.Avalonia.Uploaders/PluginSystem/UploaderProviderBase.cs
+++ b/src/ShareX.Avalonia.Uploaders/PluginSystem/UploaderProviderBase.cs
@@ -85,4 +85,17 @@ public abstract class UploaderProviderBase : IUploaderProvider
         var defaultConfig = Activator.CreateInstance(ConfigModelType);
         return JsonConvert.SerializeObject(defaultConfig, Formatting.Indented);
     }
+
+    /// <summary>
+    /// Event raised when the provider's configuration has changed
+    /// </summary>
+    public event EventHandler? ConfigChanged;
+
+    /// <summary>
+    /// Raises the ConfigChanged event. Derived classes should call this when their config is modified.
+    /// </summary>
+    public virtual void OnConfigChanged()
+    {
+        ConfigChanged?.Invoke(this, EventArgs.Empty);
+    }
 }


### PR DESCRIPTION
Introduces event handlers and event definitions for configuration changes in uploader plugins and providers, enabling automatic saving of UploadersConfig when changes occur. Implements auto-save for general settings and hotkeys when properties are modified. Updates name pattern defaults and ensures two-way binding for relevant settings fields in the UI.