### PR TITLE
Fix null flow warnings CS8600 CS8602 CS8603 across core code

### DIFF
--- a/docs/warnings/warning-plan.md
+++ b/docs/warnings/warning-plan.md
@@ -41,7 +41,7 @@ Count Code
 
 - Batch 1 - Nullability initialisation (CS8618) in DTOs/settings/viewmodels: **in progress** (Common/Uploaders/Media/History initialised)
 - Batch 2 - Optional parameter nullability (CS8625/CS8604/CS8601): **in progress** (helpers, crypto, registry, zip)
-- Batch 3 - Null flow returns/dereferences (CS8600/CS8602/CS8603): **todo**
+- Batch 3 - Null flow returns/dereferences (CS8600/CS8602/CS8603): **in progress** (early fixes in Common/Uploaders)
 - Batch 4 - Platform compatibility guards (CA1416): **todo**
 - Batch 5 - Obsolete APIs and analyser warnings (CS0618/SYSLIB*/CA2022/WFDEV005): **todo**
 - Batch 6 - Cleanup remaining small sets (CS0067/CS0649/etc): **todo**
@@ -49,7 +49,7 @@ Count Code
 ## Latest rebuild
 
 - Command: `dotnet build /t:Rebuild`
-- Warnings: 1039
+- Warnings: 1032
 - Log: `warnings.log`
 
 ### Current counts by code (post-batch-1 pass)
@@ -59,13 +59,13 @@ Count Code
 ----- ----
  502  CS8618
  484  CA1416
- 256  CS8603
- 232  CS8625
+ 248  CS8603
+ 228  CS8625
  228  CS8600
   88  CS8602
   76  CS8601
   70  CS8765
-  62  CS8604
+  60  CS8604
   16  CS0618
    8  CS0067
    8  CS8605

--- a/docs/warnings/warning-report.tsv
+++ b/docs/warnings/warning-report.tsv
@@ -47,13 +47,13 @@ CS8602     ShareX.Avalonia.Platform.Windows.csproj          4
 CS8602     ShareX.Avalonia.UI.csproj                       18
 CS8602     ShareX.Avalonia.Uploaders.csproj                22
 CS8603     ShareX.AmazonS3.Plugin.csproj                    2
-CS8603     ShareX.Avalonia.Common.csproj                  144
+CS8603     ShareX.Avalonia.Common.csproj                  138
 CS8603     ShareX.Avalonia.History.csproj                   8
 CS8603     ShareX.Avalonia.Media.csproj                     6
 CS8603     ShareX.Avalonia.UI.csproj                        2
-CS8603     ShareX.Avalonia.Uploaders.csproj                92
+CS8603     ShareX.Avalonia.Uploaders.csproj                90
 CS8603     ShareX.Imgur.Plugin.csproj                       2
-CS8604     ShareX.Avalonia.Common.csproj                   30
+CS8604     ShareX.Avalonia.Common.csproj                   28
 CS8604     ShareX.Avalonia.Core.csproj                      4
 CS8604     ShareX.Avalonia.History.csproj                   4
 CS8604     ShareX.Avalonia.Media.csproj                     2
@@ -72,7 +72,7 @@ CS8618     ShareX.Avalonia.Media.csproj                    26
 CS8618     ShareX.Avalonia.UI.csproj                       26
 CS8618     ShareX.Avalonia.Uploaders.csproj               326
 CS8625     ShareX.AmazonS3.Plugin.csproj                    2
-CS8625     ShareX.Avalonia.Common.csproj                   26
+CS8625     ShareX.Avalonia.Common.csproj                   22
 CS8625     ShareX.Avalonia.History.csproj                   2
 CS8625     ShareX.Avalonia.Indexer.csproj                   2
 CS8625     ShareX.Avalonia.Platform.Windows.csproj          2

--- a/src/ShareX.Avalonia.Common/CLI/CLIManager.cs
+++ b/src/ShareX.Avalonia.Common/CLI/CLIManager.cs
@@ -145,12 +145,12 @@ namespace XerahS.Common
             return false;
         }
 
-        public CLICommand GetCommand(string command)
+        public CLICommand? GetCommand(string command)
         {
             return Commands.Find(x => x.CheckCommand(command));
         }
 
-        public string GetParameter(string command)
+        public string? GetParameter(string command)
         {
             CLICommand cliCommand = GetCommand(command);
 

--- a/src/ShareX.Avalonia.Common/DebugTimer.cs
+++ b/src/ShareX.Avalonia.Common/DebugTimer.cs
@@ -59,12 +59,12 @@ namespace XerahS.Common
             }
         }
 
-        public void WriteElapsedMilliseconds(string text = null)
+        public void WriteElapsedMilliseconds(string? text = null)
         {
             Write(Elapsed.TotalMilliseconds.ToString("0.000", CultureInfo.InvariantCulture) + " milliseconds.", text);
         }
 
-        public void WriteElapsedSeconds(string text = null)
+        public void WriteElapsedSeconds(string? text = null)
         {
             Write(Elapsed.TotalSeconds.ToString("0.000", CultureInfo.InvariantCulture) + " seconds.", text);
         }

--- a/src/ShareX.Avalonia.Common/Zip/ZipManager.cs
+++ b/src/ShareX.Avalonia.Common/Zip/ZipManager.cs
@@ -79,8 +79,12 @@ namespace XerahS.Common
                         }
                         else
                         {
-                            Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
-                            ExtractToFile(entry, fullPath, true);
+                            string? directory = Path.GetDirectoryName(fullPath);
+                            if (!string.IsNullOrEmpty(directory))
+                            {
+                                Directory.CreateDirectory(directory);
+                                ExtractToFile(entry, fullPath, true);
+                            }
                         }
                     }
                 }
@@ -123,7 +127,7 @@ namespace XerahS.Common
 
         public static void Compress(string archivePath, List<ZipEntryInfo> entries, CompressionLevel compression = CompressionLevel.Optimal)
         {
-            string directory = Path.GetDirectoryName(archivePath);
+            string? directory = Path.GetDirectoryName(archivePath);
 
             if (!string.IsNullOrEmpty(directory))
             {

--- a/src/ShareX.Avalonia.Uploaders/UploadResult.cs
+++ b/src/ShareX.Avalonia.Uploaders/UploadResult.cs
@@ -105,7 +105,7 @@ namespace XerahS.Uploaders
                 return Errors.ToString();
             }
 
-            return null;
+            return string.Empty;
         }
 
         public string ToSummaryString()


### PR DESCRIPTION
This pull request continues the effort to reduce nullability-related warnings and improve code safety and clarity. It updates documentation to reflect progress, refines code to handle potential null values more safely, and makes minor improvements to warning handling and method signatures.

**Nullability and warning reduction progress:**

* Updated `docs/warnings/warning-plan.md` to show that Batch 3 (null flow returns/dereferences) is now in progress and reduced the total warning count from 1039 to 1032. Counts for specific warnings (CS8603, CS8625, CS8604) have decreased, reflecting recent code fixes. [[1]](diffhunk://#diff-39d146d9704fd11d971930958025e71e7ac9e2f2b9cb8478020f58338196f5a8L44-R52) [[2]](diffhunk://#diff-39d146d9704fd11d971930958025e71e7ac9e2f2b9cb8478020f58338196f5a8L62-R68)
* Updated `docs/warnings/warning-report.tsv` to decrease warning counts for CS8603, CS8604, and CS8625 in several projects, indicating progress in resolving these issues. [[1]](diffhunk://#diff-1c8a0806855b5f141be6267c769e5e023226344b1f9af9aa25ee1eeda21560daL50-R56) [[2]](diffhunk://#diff-1c8a0806855b5f141be6267c769e5e023226344b1f9af9aa25ee1eeda21560daL75-R75)

**Code improvements for nullability:**

* Changed return types in `CLIManager.cs` (`GetCommand` and `GetParameter`) and in `DebugTimer.cs` (`WriteElapsedMilliseconds` and `WriteElapsedSeconds`) to use nullable reference types (`?`) for better null safety and clarity. [[1]](diffhunk://#diff-13795300d147527cd570e56931c94ba14d51c8203f1885c3159029b6494ac1c7L148-R153) [[2]](diffhunk://#diff-5ad19c505e2bf02e502a787a203bc4db923beb1abd2cded4b255c98ef8b3d946L62-R67)
* Improved directory creation logic in `ZipManager.cs` to handle possible null values from `Path.GetDirectoryName`, preventing potential exceptions. [[1]](diffhunk://#diff-cc4ae6d662e847b20f665124790b6269c4953adbeeb0585564ba2107d2d188abL82-R92) [[2]](diffhunk://#diff-cc4ae6d662e847b20f665124790b6269c4953adbeeb0585564ba2107d2d188abL126-R130)

**Minor bug fix:**

* Changed the `ErrorsToString` method in `UploadResult.cs` to return an empty string instead of `null` when there are no errors, simplifying downstream string handling.