### PR TITLE
Claude/fix region capture hotkey hks1h

### DIFF
--- a/src/XerahS.UI/Views/RegionCapture/RegionCaptureWindow.axaml
+++ b/src/XerahS.UI/Views/RegionCapture/RegionCaptureWindow.axaml
@@ -18,60 +18,51 @@
         CanResize="False"
         WindowStartupLocation="Manual">
     
-    <Canvas Name="SelectionCanvas" 
-            HorizontalAlignment="Left" 
-            VerticalAlignment="Top" 
-            Margin="0">
-        <!-- Background screenshots container -->
-        <Canvas Name="BackgroundContainer" />
-        
-        <!-- NEW: SkiaSharp-based drawing canvas -->
+    <Panel Background="Transparent">
+        <!-- SkiaSharp-based drawing canvas -->
         <local:RegionCaptureCanvas Name="CaptureCanvas"
                                    Width="{Binding $parent[Window].Width}"
                                    Height="{Binding $parent[Window].Height}" />
         
-        <!-- Resize Handles (keeping existing implementation for logic, though visual might overlap) 
-             Ideally these should also be drawn by Skia, but for now let's keep them on top unless successful refactor allows removal.
-             Actually, the user wants "use SkiaSharp throughout". 
-             However, the plan was just to "Replace the current XAML-based dashed rectangle and darkening overlay".
-             The handles are less critical for the specific "dashed rectangle" bug, but let's see. 
-             If I hide them here, I break functionality unless I implement hit testing in the Canvas.
-             Let's KEEP them for interaction but ensure they are on top. -->
-        <Canvas Name="ResizeHandlesCanvas" IsVisible="False" IsHitTestVisible="False">
-            <Rectangle Name="HandleTL" Width="6" Height="6" Fill="White" Stroke="Black" StrokeThickness="1" />
-            <Rectangle Name="HandleTM" Width="6" Height="6" Fill="White" Stroke="Black" StrokeThickness="1" />
-            <Rectangle Name="HandleTR" Width="6" Height="6" Fill="White" Stroke="Black" StrokeThickness="1" />
-            <Rectangle Name="HandleRM" Width="6" Height="6" Fill="White" Stroke="Black" StrokeThickness="1" />
-            <Rectangle Name="HandleBR" Width="6" Height="6" Fill="White" Stroke="Black" StrokeThickness="1" />
-            <Rectangle Name="HandleBM" Width="6" Height="6" Fill="White" Stroke="Black" StrokeThickness="1" />
-            <Rectangle Name="HandleBL" Width="6" Height="6" Fill="White" Stroke="Black" StrokeThickness="1" />
-            <Rectangle Name="HandleLM" Width="6" Height="6" Fill="White" Stroke="Black" StrokeThickness="1" />
+        <!-- Overlay Canvas for UI elements -->
+        <Canvas Name="OverlayCanvas" IsHitTestVisible="False">
+            
+            <!-- Resize Handles -->
+            <Canvas Name="ResizeHandlesCanvas" IsVisible="False">
+                <Rectangle Name="HandleTL" Width="6" Height="6" Fill="White" Stroke="Black" StrokeThickness="1" />
+                <Rectangle Name="HandleTM" Width="6" Height="6" Fill="White" Stroke="Black" StrokeThickness="1" />
+                <Rectangle Name="HandleTR" Width="6" Height="6" Fill="White" Stroke="Black" StrokeThickness="1" />
+                <Rectangle Name="HandleRM" Width="6" Height="6" Fill="White" Stroke="Black" StrokeThickness="1" />
+                <Rectangle Name="HandleBR" Width="6" Height="6" Fill="White" Stroke="Black" StrokeThickness="1" />
+                <Rectangle Name="HandleBM" Width="6" Height="6" Fill="White" Stroke="Black" StrokeThickness="1" />
+                <Rectangle Name="HandleBL" Width="6" Height="6" Fill="White" Stroke="Black" StrokeThickness="1" />
+                <Rectangle Name="HandleLM" Width="6" Height="6" Fill="White" Stroke="Black" StrokeThickness="1" />
+            </Canvas>
+            
+            <!-- Magnifier HUD -->
+            <StackPanel Name="InfoStack" Orientation="Vertical" IsVisible="False">
+                 <Border Name="MagnifierBorder" 
+                         BorderBrush="White" 
+                         BorderThickness="1" 
+                         Width="120" Height="120"
+                         IsVisible="True" 
+                         Background="Black"
+                         Margin="0,0,0,5">
+                     <Grid>
+                        <Image Name="MagnifierImage" Stretch="None" />
+                         <Line StartPoint="60,0" EndPoint="60,120" Stroke="Cyan" StrokeThickness="1" Opacity="0.5"/>
+                         <Line StartPoint="0,60" EndPoint="120,60" Stroke="Cyan" StrokeThickness="1" Opacity="0.5"/>
+                     </Grid>
+                 </Border>
+            </StackPanel>
+            
+            <!-- Info Text (Floating) -->
+            <TextBlock Name="InfoText" 
+                       Background="#A0000000" 
+                       Padding="5" 
+                       Foreground="White" 
+                       FontSize="11" 
+                       IsVisible="False" />
         </Canvas>
-        
-        <!-- Info HUD (Magnifier + Text) -->
-        <StackPanel Name="InfoStack" Orientation="Vertical" IsVisible="False" IsHitTestVisible="False">
-             <!-- Magnifier: Border with Image inside -->
-             <Border Name="MagnifierBorder" 
-                     BorderBrush="White" 
-                     BorderThickness="1" 
-                     CornerRadius="0"
-                     Width="120" Height="120"
-                     IsVisible="True" 
-                     Background="Black"
-                     Margin="0,0,0,5">
-                 <Grid>
-                    <!-- Magnified Image -->
-                    <Image Name="MagnifierImage" Stretch="None" />
-                    <!-- Crosshair in magnifier -->
-                     <Line StartPoint="60,0" EndPoint="60,120" Stroke="Cyan" StrokeThickness="1" Opacity="0.5"/>
-                     <Line StartPoint="0,60" EndPoint="120,60" Stroke="Cyan" StrokeThickness="1" Opacity="0.5"/>
-                 </Grid>
-             </Border>
-
-             <!-- Text Info -->
-             <Border Background="#A0000000" CornerRadius="2" Padding="5">
-                <TextBlock Name="InfoText" Foreground="White" FontSize="11" />
-             </Border>
-        </StackPanel>
-    </Canvas>
+    </Panel>
 </Window>

--- a/src/XerahS.UI/Views/RegionCapture/RegionCaptureWindow.axaml.cs
+++ b/src/XerahS.UI/Views/RegionCapture/RegionCaptureWindow.axaml.cs
@@ -45,8 +45,8 @@ namespace XerahS.UI.Views.RegionCapture
         private RegionCaptureState _state = RegionCaptureState.Idle;
 
         // UI Cache
-        private Avalonia.Controls.Shapes.Line? _crosshairH;
-        private Avalonia.Controls.Shapes.Line? _crosshairV;
+        // private Avalonia.Controls.Shapes.Line? _crosshairH; // Obsolete
+        // private Avalonia.Controls.Shapes.Line? _crosshairV; // Obsolete
         private Canvas? _resizeHandlesCanvas;
         private StackPanel? _infoStack;
         private Image? _magnifierImage;
@@ -226,8 +226,8 @@ namespace XerahS.UI.Views.RegionCapture
             TroubleshootingHelper.Log("RegionCapture", "WINDOW", $"OnOpened state: RenderScaling={RenderScaling}, Position={Position}, Bounds={Bounds}, ClientSize={ClientSize}");
 
             // Cache UI elements
-            _crosshairH = this.FindControl<Avalonia.Controls.Shapes.Line>("CrosshairHorizontal");
-            _crosshairV = this.FindControl<Avalonia.Controls.Shapes.Line>("CrosshairVertical");
+            // _crosshairH = this.FindControl<Avalonia.Controls.Shapes.Line>("CrosshairHorizontal");
+            // _crosshairV = this.FindControl<Avalonia.Controls.Shapes.Line>("CrosshairVertical");
             _resizeHandlesCanvas = this.FindControl<Canvas>("ResizeHandlesCanvas");
             _infoStack = this.FindControl<StackPanel>("InfoStack");
             _magnifierImage = this.FindControl<Image>("MagnifierImage");
@@ -255,6 +255,9 @@ namespace XerahS.UI.Views.RegionCapture
 
             // Use new backend for positioning
             PositionWindowWithNewBackend();
+
+            // Initialize magnifier (captures screen)
+            await InitializeMagnifierBackend();
 
             // Initial pointer move check to highlight window under cursor immediately
             var mousePos = GetGlobalMousePosition();
@@ -395,18 +398,9 @@ namespace XerahS.UI.Views.RegionCapture
             DisposeNewBackend();
         }
         
-        private void UpdateCrosshair(Point p)
-        {
-            if (_crosshairH == null || _crosshairV == null) return;
-            
-            _crosshairH.StartPoint = new Point(0, p.Y);
-            _crosshairH.EndPoint = new Point(Width, p.Y);
-            _crosshairH.IsVisible = true;
-
-            _crosshairV.StartPoint = new Point(p.X, 0);
-            _crosshairV.EndPoint = new Point(p.X, Height);
-            _crosshairV.IsVisible = true;
-        }
+        /* Obsolete: Handled by RegionCaptureCanvas
+        private void UpdateCrosshair(Point p) { ... }
+        */
 
         private void UpdateMagnifierPosition(Point p)
         {


### PR DESCRIPTION
This pull request refactors the region capture overlay rendering in the `RegionCaptureWindow` by replacing the previous XAML-based drawing approach with a new custom `RegionCaptureCanvas` control that uses SkiaSharp for high-performance, artifact-free overlay rendering. It also simplifies the XAML structure and removes obsolete code related to the old overlay and crosshair implementation.

**Rendering and UI Refactor:**

* Introduced a new `RegionCaptureCanvas` control in `RegionCaptureCanvas.cs` that uses SkiaSharp for rendering the overlay, selection rectangle, and crosshairs, replacing XAML shapes to avoid rendering artifacts on transparent windows.
* Updated `RegionCaptureWindow.axaml` to use the new `RegionCaptureCanvas` for overlay rendering, removing the old XAML-based overlay, crosshair, and selection border elements. Overlay UI elements like resize handles and info HUD are now layered above the canvas. [[1]](diffhunk://#diff-086cb83d9f8f219176e69b8f88a6fd5d838df8746a3f6869a9f4ae395ec7c768R5) [[2]](diffhunk://#diff-086cb83d9f8f219176e69b8f88a6fd5d838df8746a3f6869a9f4ae395ec7c768L20-R31) [[3]](diffhunk://#diff-086cb83d9f8f219176e69b8f88a6fd5d838df8746a3f6869a9f4ae395ec7c768L71-R67)

**Code Cleanup and Obsolete Logic Removal:**

* Removed or commented out obsolete code in `RegionCaptureWindow.axaml.cs` related to XAML-based crosshairs and selection borders, delegating these responsibilities to `RegionCaptureCanvas`. [[1]](diffhunk://#diff-a55763993a3d6065b175a7cc750a5671444114513249ed803a471300f38c8e5aL48-R49) [[2]](diffhunk://#diff-a55763993a3d6065b175a7cc750a5671444114513249ed803a471300f38c8e5aL229-R230) [[3]](diffhunk://#diff-a55763993a3d6065b175a7cc750a5671444114513249ed803a471300f38c8e5aL336-R344) [[4]](diffhunk://#diff-a55763993a3d6065b175a7cc750a5671444114513249ed803a471300f38c8e5aL355-R361) [[5]](diffhunk://#diff-a55763993a3d6065b175a7cc750a5671444114513249ed803a471300f38c8e5aL401-R403)

**Magnifier and Backend Initialization:**

* Ensured the magnifier backend is initialized asynchronously on window open to support the new overlay system.

**Internal Refactoring:**

* Added a `_screenSnapshot` field in `RegionCaptureWindowNew.cs` to support future enhancements with the new backend.