### PR TITLE
Fix/frozen screen

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -64,7 +64,9 @@
       "Bash(export PATH=\"$PATH:/c/Program Files/GitHub CLI\")",
       "Bash(gh:*)",
       "Bash(\"/c/Program Files/GitHub CLI/gh\" auth status)",
-      "Bash(\"/c/Program Files/GitHub CLI/gh\" issue close 7 --repo ShareX/ShareX.Editor --comment \"Fixed in commit ab2ce24. Annotations now transform with the image during rotate/flip operations instead of being cleared. The fix uses SKMatrix transforms matching the bitmap rotation/flip, preserving annotation positions through undo/redo cycles. 11 regression tests added in XerahS.\")"
+      "Bash(git commit -m \"$\\(cat <<''EOF''\nfeat\\(toolbar\\): Refactor annotation toolbar into reusable controls \\(XIP-0023\\)\n\nCreate AnnotationToolbar and EditorToolsPanel controls for separation:\n- AnnotationToolbar: Contains all annotation drawing tools, property\n  controls \\(color, width, font size, strength, shadow\\), and actions\n  \\(undo, redo, delete, clear\\). Includes ExtensionContent slot for\n  injecting additional controls.\n- EditorToolsPanel: Contains Editor-specific tools \\(Crop, CutOut,\n  Background, Effects\\) excluded from Region Capture Overlay.\n- EditorView: Updated to use new controls with slot composition,\n  injecting EditorToolsPanel into AnnotationToolbar''s ExtensionContent.\n\nThis enables future reuse of AnnotationToolbar in the Region Capture\nOverlay for annotating screenshots during capture.\n\nCo-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>\nEOF\n\\)\")",
+      "Bash(\"/c/Program Files/GitHub CLI/gh\" issue close 7 --repo ShareX/ShareX.Editor --comment \"Fixed in commit ab2ce24. Annotations now transform with the image during rotate/flip operations instead of being cleared. The fix uses SKMatrix transforms matching the bitmap rotation/flip, preserving annotation positions through undo/redo cycles. 11 regression tests added in XerahS.\")",
+      "Bash(cd \"c:\\\\Users\\\\liveu\\\\source\\\\repos\\\\ShareX Team\\\\XerahS\\\\src\\\\XerahS.RegionCapture\"\" && find . -type f -name \"*.cs \")"
     ]
   }
 }

--- a/docs/technical/region-capture.md
+++ b/docs/technical/region-capture.md
@@ -4,7 +4,7 @@ This document outlines the technical differences and implementation details of t
 
 ## Overview
 
-XerahS supports two distinct approaches to region capture, determined by the `WorkflowType` and the underlying `RegionCaptureOptions.CaptureTransparent` property.
+XerahS supports two distinct approaches to region capture, determined by the `WorkflowType` and the underlying `RegionCaptureOptions.UseTransparentOverlay` property.
 
 | Feature | RectangleTransparent | Standard Region Capture |
 | :--- | :--- | :--- |
@@ -30,7 +30,7 @@ This flag is then passed into the `CaptureOptions` object:
 var captureOptions = new CaptureOptions
 {
     // ...
-    CaptureTransparent = useTransparentOverlay,
+    UseTransparentOverlay = useTransparentOverlay,
     // ...
 };
 ```
@@ -46,17 +46,17 @@ var captureService = new RegionCaptureService
     Options = new XerahS.RegionCapture.RegionCaptureOptions
     {
         // ...
-        CaptureTransparent = options?.CaptureTransparent ?? false,
+        UseTransparentOverlay = options?.UseTransparentOverlay ?? false,
     }
 };
 ```
 
 ### 3. Region Capture Logic (`RegionCaptureService.cs`)
 
-The `RegionCaptureService` uses the `CaptureTransparent` property to determine how to render the overlay using `OverlayManager`.
+The `RegionCaptureService` uses the `UseTransparentOverlay` property to determine how to render the overlay using `OverlayManager`.
 
--   **`CaptureTransparent = true`**: The overlay window is created with a transparent background. No initial screenshot is taken. The user sees the live desktop through the overlay.
--   **`CaptureTransparent = false`** (Default): A full-screen screenshot is captured *before* the overlay is shown. This screenshot is rendered as the background of the overlay window, creating a "frozen" effect.
+-   **`UseTransparentOverlay = true`**: The overlay window is created with a transparent background. No initial screenshot is taken. The user sees the live desktop through the overlay.
+-   **`UseTransparentOverlay = false`** (Default): A full-screen screenshot is captured *before* the overlay is shown. This screenshot is rendered as the background of the overlay window, creating a "frozen" effect.
 
 ### Key Files
 

--- a/src/XerahS.Core/Tasks/WorkerTask.cs
+++ b/src/XerahS.Core/Tasks/WorkerTask.cs
@@ -217,7 +217,7 @@ namespace XerahS.Core.Tasks
                 var isScreenCaptureDelay = workflowCategory == EnumExtensions.WorkflowType_Category_ScreenCapture && captureDelaySeconds > 0;
                 var isScreenRecordDelay = workflowCategory == EnumExtensions.WorkflowType_Category_ScreenRecord && captureDelaySeconds > 0;
 
-                // CaptureTransparent is true only for RectangleTransparent workflow
+                // UseTransparentOverlay is true only for RectangleTransparent workflow
                 // All other region capture workflows use frozen screenshot background
                 var useTransparentOverlay = taskSettings.Job == WorkflowType.RectangleTransparent;
 
@@ -225,7 +225,7 @@ namespace XerahS.Core.Tasks
                 {
                     UseModernCapture = captureSettings.UseModernCapture,
                     ShowCursor = captureSettings.ShowCursor,
-                    CaptureTransparent = useTransparentOverlay,
+                    UseTransparentOverlay = useTransparentOverlay,
                     CaptureShadow = captureSettings.CaptureShadow,
                     CaptureClientArea = captureSettings.CaptureClientArea,
                     WorkflowId = taskSettings.WorkflowId,

--- a/src/XerahS.Platform.Abstractions/CaptureOptions.cs
+++ b/src/XerahS.Platform.Abstractions/CaptureOptions.cs
@@ -31,7 +31,18 @@ namespace XerahS.Platform.Abstractions
     {
         public bool UseModernCapture { get; set; } = true;
         public bool ShowCursor { get; set; } = true;
+        /// <summary>
+        /// For window captures: capture transparent regions of the window.
+        /// This is the original ShareX CaptureTransparent setting.
+        /// </summary>
         public bool CaptureTransparent { get; set; } = false;
+
+        /// <summary>
+        /// For region captures: use transparent overlay (live desktop visible) vs frozen screenshot background.
+        /// True for RectangleTransparent workflow, false for other region capture workflows.
+        /// </summary>
+        public bool UseTransparentOverlay { get; set; } = false;
+
         public bool CaptureShadow { get; set; } = true;
         public bool CaptureClientArea { get; set; } = false;
 

--- a/src/XerahS.RegionCapture/RegionCaptureService.cs
+++ b/src/XerahS.RegionCapture/RegionCaptureService.cs
@@ -120,9 +120,10 @@ public sealed record RegionCaptureOptions
     public SkiaSharp.SKBitmap? BackgroundImage { get; init; } = null;
 
     /// <summary>
-    /// When true, the overlay is transparent showing the live desktop behind it.
+    /// When true, the overlay is transparent showing the live desktop behind it (RectangleTransparent workflow).
     /// When false, the overlay displays a frozen screenshot background (like original ShareX).
     /// Default: false (frozen screenshot background).
+    /// Note: This is different from CaptureTransparent in CaptureOptions, which controls window capture transparency.
     /// </summary>
-    public bool CaptureTransparent { get; init; } = false;
+    public bool UseTransparentOverlay { get; init; } = false;
 }

--- a/src/XerahS.RegionCapture/UI/RegionCaptureControl.cs
+++ b/src/XerahS.RegionCapture/UI/RegionCaptureControl.cs
@@ -56,7 +56,7 @@ public sealed class RegionCaptureControl : UserControl
     private readonly double _dimOpacity;
     private readonly bool _enableWindowSnapping;
     private readonly bool _enableMagnifier;
-    private readonly bool _captureTransparent;
+    private readonly bool _useTransparentOverlay;
     private readonly XerahS.Platform.Abstractions.CursorInfo? _ghostCursor;
     private readonly Bitmap? _ghostCursorBitmap;
     private readonly SkiaSharp.SKBitmap? _backgroundBitmap;
@@ -107,10 +107,10 @@ public sealed class RegionCaptureControl : UserControl
         _enableMagnifier = options.EnableMagnifier;
         _enableKeyboardNudge = options.EnableKeyboardNudge;
         _backgroundBitmap = options.BackgroundImage;
-        _captureTransparent = options.CaptureTransparent;
+        _useTransparentOverlay = options.UseTransparentOverlay;
 
         // Convert background bitmap to Avalonia Bitmap for rendering when not transparent
-        if (!_captureTransparent && _backgroundBitmap != null)
+        if (!_useTransparentOverlay && _backgroundBitmap != null)
         {
             try
             {
@@ -343,7 +343,7 @@ public sealed class RegionCaptureControl : UserControl
         var bounds = new Rect(0, 0, Bounds.Width, Bounds.Height);
 
         // Draw frozen background when not in transparent mode
-        if (!_captureTransparent && _backgroundAvBitmap != null)
+        if (!_useTransparentOverlay && _backgroundAvBitmap != null)
         {
             DrawFrozenBackground(context, bounds);
         }

--- a/src/XerahS.UI/Services/ScreenCaptureService.cs
+++ b/src/XerahS.UI/Services/ScreenCaptureService.cs
@@ -86,7 +86,7 @@ namespace XerahS.UI.Services
                         {
                             ShowCursor = options?.ShowCursor ?? false,
                             BackgroundImage = backgroundForMagnifier,
-                            CaptureTransparent = options?.CaptureTransparent ?? false,
+                            UseTransparentOverlay = options?.UseTransparentOverlay ?? false,
                         }
                     };
 
@@ -187,7 +187,7 @@ namespace XerahS.UI.Services
                         {
                             ShowCursor = options?.ShowCursor ?? false,
                             BackgroundImage = backgroundForMagnifier,
-                            CaptureTransparent = options?.CaptureTransparent ?? false,
+                            UseTransparentOverlay = options?.UseTransparentOverlay ?? false,
                         }
                     };
 


### PR DESCRIPTION
This pull request introduces a clear separation between two region capture workflows in XerahS: the traditional "frozen screenshot" mode and a new "transparent overlay" mode where the live desktop remains visible during region selection. The main goal is to make the codebase and configuration more explicit and maintainable by replacing the ambiguous `CaptureTransparent` property with a new, purpose-specific `UseTransparentOverlay` property throughout the codebase. Additionally, a technical documentation file has been added to explain these workflows.

**Region Capture Workflow Improvements:**

* Introduced a new `UseTransparentOverlay` property in `CaptureOptions` and `RegionCaptureOptions`, replacing the old `CaptureTransparent` property for region capture workflows. This clarifies the distinction between showing a live desktop (transparent overlay) and a frozen screenshot background during region selection. (`src/XerahS.Platform.Abstractions/CaptureOptions.cs` [[1]](diffhunk://#diff-b7061af8a2311b68596a61f60d2f6387a53bdafea1663bb10c5ed0cf7ccfa2f0R34-R45) `src/XerahS.RegionCapture/RegionCaptureService.cs` [[2]](diffhunk://#diff-a3c0ace9a3133f6252c59fc3c2b573ce4ea8d71d1e90c9bccfa96995e88674d7L123-R128)
* Updated all usages and internal logic to use `UseTransparentOverlay` instead of `CaptureTransparent`, ensuring consistent behavior and clearer intent across the workflow initiation, service layer, and UI rendering. (`src/XerahS.Core/Tasks/WorkerTask.cs` [[1]](diffhunk://#diff-caba146ef895c0e6e72e18c85db815bf03ec100a84ec1c9b17f22e3793873942L220-R228) `src/XerahS.UI/Services/ScreenCaptureService.cs` [[2]](diffhunk://#diff-8f0b237fa09907177b132a0307b5d1220d4c0aa9633bbe408e02c7d952229f20L88-R89) [[3]](diffhunk://#diff-8f0b237fa09907177b132a0307b5d1220d4c0aa9633bbe408e02c7d952229f20L175-R190) `src/XerahS.RegionCapture/UI/RegionCaptureControl.cs` [[4]](diffhunk://#diff-7c879e46e8efd47289ce490949cc58754e18b1e6973bfa3fa755d124df648bdfL59-R59) [[5]](diffhunk://#diff-7c879e46e8efd47289ce490949cc58754e18b1e6973bfa3fa755d124df648bdfL110-R113) [[6]](diffhunk://#diff-7c879e46e8efd47289ce490949cc58754e18b1e6973bfa3fa755d124df648bdfL346-R346)

**Technical Documentation:**

* Added a new technical documentation file, `docs/technical/region-capture.md`, detailing the differences, use cases, and implementation of the transparent overlay versus frozen background region capture workflows. This should help future contributors understand the rationale and flow.

**Screen Capture Service Enhancements:**

* Improved fallback and robustness in region capture by first attempting to use a full-screen bitmap for cropping the selection, and only falling back to live capture if this fails. This provides a more reliable user experience when capturing regions. (`src/XerahS.UI/Services/ScreenCaptureService.cs` [[1]](diffhunk://#diff-8f0b237fa09907177b132a0307b5d1220d4c0aa9633bbe408e02c7d952229f20R153-R166) [[2]](diffhunk://#diff-8f0b237fa09907177b132a0307b5d1220d4c0aa9633bbe408e02c7d952229f20R255-R284)

**Miscellaneous:**

* Updated local settings and scripts to reflect the new commit message conventions and to support development workflow improvements. (`.claude/settings.local.json` [.claude/settings.local.jsonL67-R69](diffhunk://#diff-fca16cae5b0e32edfa6b55eaa32a98ffbf4a0c7d885fb585785fc83b6ea2d9c3L67-R69))
* Minor code cleanup and import fixes. (`src/XerahS.UI/Services/ScreenCaptureService.cs` [src/XerahS.UI/Services/ScreenCaptureService.csR27](diffhunk://#diff-8f0b237fa09907177b132a0307b5d1220d4c0aa9633bbe408e02c7d952229f20R27))

These changes make the region capture codebase more explicit, robust, and easier to extend for future workflows.