### PR TITLE
Fix custom uploader compatibility check for XerahS versions

### DIFF
--- a/src/XerahS.Uploaders/CustomUploader/CustomUploaderItem.cs
+++ b/src/XerahS.Uploaders/CustomUploader/CustomUploaderItem.cs
@@ -344,6 +344,17 @@ namespace XerahS.Uploaders
 
         public void CheckBackwardCompatibility()
         {
+            // Check if this is a XerahS custom uploader (versions 0.x.x)
+            bool isXerahSVersion = !string.IsNullOrEmpty(Version) && Version.StartsWith("0.");
+
+            if (isXerahSVersion)
+            {
+                // XerahS custom uploaders use modern syntax, no migration needed
+                CheckRequestURL();
+                return;
+            }
+
+            // Legacy ShareX compatibility checks
             if (string.IsNullOrEmpty(Version) || GeneralHelpers.CompareVersion(Version, "12.3.1") <= 0)
             {
                 throw new Exception("Unsupported custom uploader" + ": " + ToString());

--- a/tests/ShareX.Avalonia.Tests/CustomUploader/CustomUploaderRepositoryTests.cs
+++ b/tests/ShareX.Avalonia.Tests/CustomUploader/CustomUploaderRepositoryTests.cs
@@ -192,4 +192,72 @@ public class CustomUploaderRepositoryTests
         Assert.That(loaded.IsValid, Is.False);
         Assert.That(loaded.LoadError, Does.Contain("Invalid JSON"));
     }
+
+    [Test]
+    public void CheckBackwardCompatibility_AcceptsXerahSVersions()
+    {
+        // Arrange - Create a custom uploader with XerahS version
+        var json = @"{
+            ""Version"": ""0.8.1"",
+            ""Name"": ""Test Uploader"",
+            ""DestinationType"": 7,
+            ""RequestMethod"": 1,
+            ""RequestURL"": ""https://example.com/upload"",
+            ""Body"": 1,
+            ""FileFormName"": ""file"",
+            ""URL"": ""{json:url}""
+        }";
+
+        // Act
+        var loaded = CustomUploaderRepository.LoadFromJson(json, "test.sxcu");
+
+        // Assert
+        Assert.That(loaded.IsValid, Is.True, $"XerahS version should be accepted: {loaded.LoadError}");
+        Assert.That(loaded.Item.Version, Is.EqualTo("0.8.1"));
+    }
+
+    [Test]
+    public void CheckBackwardCompatibility_RejectsOldShareXVersions()
+    {
+        // Arrange - Create a custom uploader with old ShareX version
+        var json = @"{
+            ""Version"": ""12.0.0"",
+            ""Name"": ""Test Uploader"",
+            ""DestinationType"": 7,
+            ""RequestMethod"": 1,
+            ""RequestURL"": ""https://example.com/upload"",
+            ""Body"": 1,
+            ""FileFormName"": ""file"",
+            ""URL"": ""{json:url}""
+        }";
+
+        // Act
+        var loaded = CustomUploaderRepository.LoadFromJson(json, "test.sxcu");
+
+        // Assert
+        Assert.That(loaded.IsValid, Is.False);
+        Assert.That(loaded.LoadError, Does.Contain("Unsupported custom uploader"));
+    }
+
+    [Test]
+    public void CheckBackwardCompatibility_AcceptsModernShareXVersions()
+    {
+        // Arrange - Create a custom uploader with modern ShareX version
+        var json = @"{
+            ""Version"": ""14.0.0"",
+            ""Name"": ""Test Uploader"",
+            ""DestinationType"": 7,
+            ""RequestMethod"": 1,
+            ""RequestURL"": ""https://example.com/upload"",
+            ""Body"": 1,
+            ""FileFormName"": ""file"",
+            ""URL"": ""{json:url}""
+        }";
+
+        // Act
+        var loaded = CustomUploaderRepository.LoadFromJson(json, "test.sxcu");
+
+        // Assert
+        Assert.That(loaded.IsValid, Is.True, $"Modern ShareX version should be accepted: {loaded.LoadError}");
+    }
 }


### PR DESCRIPTION
## Problem

When using the import tool or creating custom uploaders in XerahS, the version field is set to the current application version (e.g., `0.8.1`). However, the `CheckBackwardCompatibility()` method was rejecting any version ≤ `12.3.1`, which is based on ShareX's version numbering scheme (12.x, 13.x, 14.x).

This caused all XerahS-created custom uploaders to fail with:
```
Compatibility check failed: Unsupported custom uploader: <uploader name>
```

## Solution

Updated the `CheckBackwardCompatibility()` method in `CustomUploaderItem.cs` to:
- Recognize XerahS versions (0.x.x) as valid
- Skip legacy ShareX migration logic for XerahS custom uploaders
- Maintain backward compatibility for ShareX custom uploaders (12.3.1+)

## Changes

- Modified `src/XerahS.Uploaders/CustomUploader/CustomUploaderItem.cs:345-365`
  - Added check for XerahS version pattern (starts with "0.")
  - XerahS uploaders bypass old version checks
  - ShareX uploaders continue to work with existing migration logic
  
- Added tests in `tests/ShareX.Avalonia.Tests/CustomUploader/CustomUploaderRepositoryTests.cs`
  - Test for XerahS version acceptance (0.8.1)
  - Test for old ShareX version rejection (12.0.0)
  - Test for modern ShareX version acceptance (14.0.0)

## Testing

The fix ensures:
- ✅ Custom uploaders created by XerahS (version 0.x.x) load successfully
- ✅ Custom uploaders imported from modern ShareX (version > 12.3.1) continue to work
- ✅ Old ShareX custom uploaders (version ≤ 12.3.1) are properly rejected
- ✅ Backward compatibility is maintained for all existing workflows

## Related Issues

Fixes the issue where imported or newly created custom uploaders fail compatibility checks due to version number mismatch between XerahS (0.x.x) and ShareX (12.x+) versioning schemes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2FShareX%2FXerahS%2Fpull%2F71&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->