### PR TITLE
Fix CA1416 warning for DPAPI calls

### DIFF
--- a/src/XerahS.Core/Security/SecretStore.cs
+++ b/src/XerahS.Core/Security/SecretStore.cs
@@ -25,6 +25,7 @@
 
 using Newtonsoft.Json;
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using System.Security.Cryptography;
 using System.Text;
 using XerahS.Common;
@@ -128,6 +129,7 @@ public sealed class SecretStore : ISecretStore, ISecretStoreInfo
         return Path.Combine(directory, "SecretsStore.key");
     }
 
+    [SupportedOSPlatform("windows")]
     private sealed class DpapiFileSecretStore : ISecretStore
     {
         private readonly object _lock = new();


### PR DESCRIPTION
Added [SupportedOSPlatform("windows")] to DpapiFileSecretStore since it uses Windows-only DPAPI methods.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2FShareX%2FXerahS%2Fpull%2F73&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->