### PR TITLE
Fix custom uploader loading and add configuration UI

### DIFF
--- a/src/XerahS.UI/ViewModels/CustomUploaderConfigViewModel.cs
+++ b/src/XerahS.UI/ViewModels/CustomUploaderConfigViewModel.cs
@@ -1,0 +1,147 @@
+#region License Information (GPL v3)
+
+/*
+    XerahS - The Avalonia UI implementation of ShareX
+    Copyright (c) 2007-2026 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Newtonsoft.Json;
+using XerahS.Uploaders;
+using XerahS.Uploaders.PluginSystem;
+using System.Collections.ObjectModel;
+
+namespace XerahS.UI.ViewModels;
+
+/// <summary>
+/// ViewModel for custom uploader configuration in the settings panel
+/// </summary>
+public partial class CustomUploaderConfigViewModel : ObservableObject, IUploaderConfigViewModel
+{
+    private CustomUploaderItem _item = CustomUploaderItem.Init();
+
+    [ObservableProperty]
+    private string _requestUrl = string.Empty;
+
+    [ObservableProperty]
+    private string _requestMethod = "POST";
+
+    [ObservableProperty]
+    private string _bodyType = "MultipartFormData";
+
+    [ObservableProperty]
+    private string _fileFormName = "file";
+
+    [ObservableProperty]
+    private string _urlSyntax = string.Empty;
+
+    [ObservableProperty]
+    private int _headerCount;
+
+    [ObservableProperty]
+    private int _parameterCount;
+
+    [ObservableProperty]
+    private int _argumentCount;
+
+    public CustomUploaderConfigViewModel()
+    {
+    }
+
+    public void LoadFromJson(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            _item = CustomUploaderItem.Init();
+        }
+        else
+        {
+            try
+            {
+                var item = JsonConvert.DeserializeObject<CustomUploaderItem>(json);
+                _item = item ?? CustomUploaderItem.Init();
+            }
+            catch
+            {
+                _item = CustomUploaderItem.Init();
+            }
+        }
+
+        UpdatePropertiesFromItem();
+    }
+
+    public string ToJson()
+    {
+        return JsonConvert.SerializeObject(_item, Formatting.Indented, new JsonSerializerSettings
+        {
+            DefaultValueHandling = DefaultValueHandling.Ignore,
+            NullValueHandling = NullValueHandling.Ignore
+        });
+    }
+
+    public bool Validate()
+    {
+        return !string.IsNullOrWhiteSpace(_item.RequestURL);
+    }
+
+    [RelayCommand]
+    private async Task EditAdvanced()
+    {
+        var editorViewModel = new CustomUploaderEditorViewModel();
+        editorViewModel.LoadFromItem(_item);
+
+        var dialog = new Views.CustomUploaderEditorDialog
+        {
+            DataContext = editorViewModel
+        };
+
+        var mainWindow = Avalonia.Application.Current?.ApplicationLifetime is Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop
+            ? desktop.MainWindow
+            : null;
+
+        if (mainWindow != null)
+        {
+            var result = await dialog.ShowDialog<bool>(mainWindow);
+            if (result)
+            {
+                _item = editorViewModel.ToItem();
+                UpdatePropertiesFromItem();
+                OnPropertyChanged(nameof(_item)); // Notify parent that data changed
+            }
+        }
+    }
+
+    private void UpdatePropertiesFromItem()
+    {
+        RequestUrl = _item.RequestURL ?? string.Empty;
+        RequestMethod = _item.RequestMethod.ToString();
+        BodyType = _item.Body.ToString();
+        FileFormName = _item.FileFormName ?? "file";
+        UrlSyntax = _item.URL ?? string.Empty;
+
+        HeaderCount = _item.Headers?.Count ?? 0;
+        ParameterCount = _item.Parameters?.Count ?? 0;
+        ArgumentCount = _item.Arguments?.Count ?? 0;
+    }
+
+    public CustomUploaderItem GetItem() => _item;
+}

--- a/src/XerahS.UI/ViewModels/UploaderInstanceViewModel.cs
+++ b/src/XerahS.UI/ViewModels/UploaderInstanceViewModel.cs
@@ -171,9 +171,17 @@ public partial class UploaderInstanceViewModel : ViewModelBase
             Common.DebugHelper.WriteLine($"[UploaderInstanceVM] Provider found: {provider.Name}");
 
             ConfigViewModel = provider.CreateConfigViewModel();
-            Common.DebugHelper.WriteLine($"[UploaderInstanceVM] ConfigViewModel created: {ConfigViewModel?.GetType().Name ?? "null"}");
-
             ConfigView = provider.CreateConfigView();
+
+            // Special handling for custom uploaders
+            if (ConfigViewModel == null && ConfigView == null && ProviderId.StartsWith("custom_", StringComparison.OrdinalIgnoreCase))
+            {
+                Common.DebugHelper.WriteLine($"[UploaderInstanceVM] Creating custom uploader config view/viewmodel");
+                ConfigViewModel = new CustomUploaderConfigViewModel();
+                ConfigView = new Views.CustomUploaderConfigView();
+            }
+
+            Common.DebugHelper.WriteLine($"[UploaderInstanceVM] ConfigViewModel created: {ConfigViewModel?.GetType().Name ?? "null"}");
             Common.DebugHelper.WriteLine($"[UploaderInstanceVM] ConfigView created: {ConfigView?.GetType().Name ?? "null"}");
 
             if (ConfigViewModel is IProviderContextAware contextAware)

--- a/src/XerahS.UI/Views/CustomUploaderConfigView.axaml
+++ b/src/XerahS.UI/Views/CustomUploaderConfigView.axaml
@@ -1,0 +1,103 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:XerahS.UI.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="350"
+             x:Class="XerahS.UI.Views.CustomUploaderConfigView"
+             x:DataType="vm:CustomUploaderConfigViewModel">
+
+    <StackPanel Spacing="16">
+
+        <!-- Request Info -->
+        <StackPanel Spacing="8">
+            <TextBlock Text="Request Configuration" FontWeight="SemiBold"/>
+
+            <Grid ColumnDefinitions="Auto,12,*" RowDefinitions="Auto,8,Auto,8,Auto,8,Auto" >
+                <TextBlock Grid.Row="0" Grid.Column="0" Text="URL:" VerticalAlignment="Center"/>
+                <TextBlock Grid.Row="0" Grid.Column="2"
+                           Text="{Binding RequestUrl}"
+                           TextTrimming="CharacterEllipsis"
+                           ToolTip.Tip="{Binding RequestUrl}"
+                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+
+                <TextBlock Grid.Row="2" Grid.Column="0" Text="Method:" VerticalAlignment="Center"/>
+                <TextBlock Grid.Row="2" Grid.Column="2"
+                           Text="{Binding RequestMethod}"
+                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+
+                <TextBlock Grid.Row="4" Grid.Column="0" Text="Body Type:" VerticalAlignment="Center"/>
+                <TextBlock Grid.Row="4" Grid.Column="2"
+                           Text="{Binding BodyType}"
+                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+
+                <TextBlock Grid.Row="6" Grid.Column="0" Text="File Field:" VerticalAlignment="Center"/>
+                <TextBlock Grid.Row="6" Grid.Column="2"
+                           Text="{Binding FileFormName}"
+                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+            </Grid>
+        </StackPanel>
+
+        <!-- Response Parsing -->
+        <StackPanel Spacing="8" IsVisible="{Binding UrlSyntax, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+            <TextBlock Text="Response Parsing" FontWeight="SemiBold"/>
+            <Grid ColumnDefinitions="Auto,12,*">
+                <TextBlock Grid.Column="0" Text="URL Syntax:" VerticalAlignment="Center"/>
+                <TextBlock Grid.Column="2"
+                           Text="{Binding UrlSyntax}"
+                           TextTrimming="CharacterEllipsis"
+                           ToolTip.Tip="{Binding UrlSyntax}"
+                           FontFamily="Consolas, Monospace"
+                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+            </Grid>
+        </StackPanel>
+
+        <!-- Additional Configuration -->
+        <StackPanel Spacing="8">
+            <TextBlock Text="Additional Configuration" FontWeight="SemiBold"/>
+            <WrapPanel Orientation="Horizontal">
+                <StackPanel Orientation="Horizontal" Spacing="4" Margin="0,0,16,0">
+                    <TextBlock Text="Headers:" VerticalAlignment="Center"/>
+                    <TextBlock Text="{Binding HeaderCount}"
+                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                               VerticalAlignment="Center"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Spacing="4" Margin="0,0,16,0">
+                    <TextBlock Text="Parameters:" VerticalAlignment="Center"/>
+                    <TextBlock Text="{Binding ParameterCount}"
+                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                               VerticalAlignment="Center"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Spacing="4">
+                    <TextBlock Text="Arguments:" VerticalAlignment="Center"/>
+                    <TextBlock Text="{Binding ArgumentCount}"
+                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                               VerticalAlignment="Center"/>
+                </StackPanel>
+            </WrapPanel>
+        </StackPanel>
+
+        <!-- Edit Button -->
+        <Button Content="Edit Advanced Settings"
+                Command="{Binding EditAdvancedCommand}"
+                HorizontalAlignment="Left"
+                AutomationProperties.Name="Edit Advanced Custom Uploader Settings"/>
+
+        <!-- Info -->
+        <Border Background="{DynamicResource SystemFillColorAttentionBackground}"
+                BorderBrush="{DynamicResource SystemFillColorAttentionBrush}"
+                BorderThickness="1"
+                CornerRadius="4"
+                Padding="12">
+            <StackPanel Spacing="4">
+                <TextBlock Text="Custom Uploader"
+                           FontWeight="SemiBold"/>
+                <TextBlock Text="This is a custom HTTP-based uploader. Click 'Edit Advanced Settings' to modify request configuration, headers, body format, and response parsing."
+                           TextWrapping="Wrap"
+                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                           FontSize="12"/>
+            </StackPanel>
+        </Border>
+
+    </StackPanel>
+</UserControl>

--- a/src/XerahS.UI/Views/CustomUploaderConfigView.axaml.cs
+++ b/src/XerahS.UI/Views/CustomUploaderConfigView.axaml.cs
@@ -1,0 +1,36 @@
+#region License Information (GPL v3)
+
+/*
+    XerahS - The Avalonia UI implementation of ShareX
+    Copyright (c) 2007-2026 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using Avalonia.Controls;
+
+namespace XerahS.UI.Views;
+
+public partial class CustomUploaderConfigView : UserControl
+{
+    public CustomUploaderConfigView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/XerahS.UI/Views/DestinationSettingsView.axaml
+++ b/src/XerahS.UI/Views/DestinationSettingsView.axaml
@@ -193,7 +193,7 @@
                             </StackPanel>
 
                             <!-- Custom Config -->
-                            <StackPanel Spacing="8">
+                            <StackPanel Spacing="8" IsVisible="{Binding SelectedCategory.SelectedInstance.ConfigView, Converter={x:Static ObjectConverters.IsNotNull}}">
                                 <TextBlock Text="Provider Settings" FontWeight="SemiBold" FontSize="16"/>
                                 <ContentControl Content="{Binding SelectedCategory.SelectedInstance.ConfigView}"/>
                             </StackPanel>

--- a/src/XerahS.Uploaders/PluginSystem/PluginConfigurationVerifier.cs
+++ b/src/XerahS.Uploaders/PluginSystem/PluginConfigurationVerifier.cs
@@ -86,6 +86,15 @@ public static class PluginConfigurationVerifier
     {
         var result = new PluginVerificationResult();
 
+        // Custom uploaders are single .sxcu files, not plugin folders - skip verification
+        if (providerId.StartsWith("custom_", StringComparison.OrdinalIgnoreCase))
+        {
+            result.Status = PluginVerificationStatus.Valid;
+            result.Message = "Custom uploader (.sxcu file)";
+            result.Issues.Add("Custom uploaders are single JSON files and do not require folder verification.");
+            return result;
+        }
+
         // Find plugin folder
         var pluginsPath = Path.Combine(PathsManager.PluginsFolder, providerId);
 


### PR DESCRIPTION
- Fixed PluginConfigurationVerifier to skip folder verification for custom uploaders (.sxcu files)
- Added CustomUploaderConfigViewModel and CustomUploaderConfigView for configuring custom uploaders in settings
- Updated UploaderInstanceViewModel to create config view/viewmodel for custom uploaders
- Made Provider Settings section conditional (only visible when ConfigView exists)
- Custom uploaders now display configuration summary with edit button

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2FShareX%2FXerahS%2Fpull%2F74&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->