### PR TITLE
feat: Adds Custom Uploader support to Mobile UI

### DIFF
--- a/src/XerahS.Common/PathsManager.cs
+++ b/src/XerahS.Common/PathsManager.cs
@@ -68,6 +68,8 @@ namespace XerahS.Common
             get
             {
 #if DEBUG
+                if (OperatingSystem.IsIOS() || OperatingSystem.IsAndroid())
+                    return Path.Combine(PersonalFolder, AppResources.PluginsFolderName);
                 return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, AppResources.PluginsFolderName);
 #else
                 return Path.Combine(PersonalFolder, AppResources.PluginsFolderName);

--- a/src/XerahS.Mobile.UI/ViewModels/MobileCustomUploaderConfigViewModel.cs
+++ b/src/XerahS.Mobile.UI/ViewModels/MobileCustomUploaderConfigViewModel.cs
@@ -1,0 +1,982 @@
+#region License Information (GPL v3)
+
+/*
+    XerahS - The Avalonia UI implementation of ShareX
+    Copyright (c) 2007-2026 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using XerahS.Common;
+using XerahS.Core;
+using XerahS.Uploaders;
+using XerahS.Uploaders.CustomUploader;
+using XerahS.Uploaders.PluginSystem;
+
+namespace XerahS.Mobile.UI.ViewModels;
+
+/// <summary>
+/// Represents a custom uploader entry in the list.
+/// </summary>
+public class CustomUploaderListItem
+{
+    public string Name { get; set; } = "";
+    public string HostName { get; set; } = "";
+    public int Index { get; set; }
+    public bool IsActive { get; set; }
+}
+
+/// <summary>
+/// Key/value pair for headers, parameters, and arguments collections.
+/// </summary>
+public class KeyValuePairItem : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private string _key = "";
+    public string Key
+    {
+        get => _key;
+        set { _key = value; OnPropertyChanged(); }
+    }
+
+    private string _value = "";
+    public string Value
+    {
+        get => _value;
+        set { _value = value; OnPropertyChanged(); }
+    }
+
+    public ICommand? RemoveCommand { get; set; }
+
+    protected void OnPropertyChanged([CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}
+
+/// <summary>
+/// Mobile-friendly ViewModel for Custom Uploader configuration.
+/// Provides a form-based editor (recreated from the desktop CustomUploaderEditorDialog)
+/// and a list view to manage custom uploaders.
+/// </summary>
+[MobileUploaderConfig("customuploader", "Custom Uploader", 2)]
+public class MobileCustomUploaderConfigViewModel : IMobileUploaderConfig, INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    #region Static Data
+
+    public static IReadOnlyList<string> HttpMethods { get; } = new[] { "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD" };
+    public static IReadOnlyList<string> BodyTypes { get; } = new[] { "No body", "Form data (multipart)", "Form URL encoded", "JSON", "XML", "Binary" };
+
+    #endregion
+
+    #region IMobileUploaderConfig Properties
+
+    public string UploaderName => "Custom Uploader";
+    public string IconPath => "CloudUpload";
+    public string Description => IsConfigured
+        ? $"Active: {ActiveUploaderName}"
+        : "Not configured - tap to set up";
+
+    private bool _isConfigured;
+    public bool IsConfigured
+    {
+        get => _isConfigured;
+        private set { _isConfigured = value; OnPropertyChanged(); OnPropertyChanged(nameof(Description)); }
+    }
+
+    #endregion
+
+    #region List View Properties
+
+    private ObservableCollection<CustomUploaderListItem> _customUploaders = new();
+    public ObservableCollection<CustomUploaderListItem> CustomUploaders
+    {
+        get => _customUploaders;
+        set { _customUploaders = value; OnPropertyChanged(); }
+    }
+
+    private int _selectedUploaderIndex = -1;
+    public int SelectedUploaderIndex
+    {
+        get => _selectedUploaderIndex;
+        set { _selectedUploaderIndex = value; OnPropertyChanged(); }
+    }
+
+    public string ActiveUploaderName
+    {
+        get
+        {
+            var activeIndex = SettingsManager.UploadersConfig?.CustomImageUploaderSelected ?? -1;
+            var list = SettingsManager.UploadersConfig?.CustomUploadersList;
+            if (list != null && activeIndex >= 0 && activeIndex < list.Count)
+                return list[activeIndex].ToString();
+            return "None";
+        }
+    }
+
+    private bool _isTesting;
+    public bool IsTesting
+    {
+        get => _isTesting;
+        set { _isTesting = value; OnPropertyChanged(); }
+    }
+
+    #endregion
+
+    #region Editor Properties
+
+    private bool _isEditorVisible;
+    public bool IsEditorVisible
+    {
+        get => _isEditorVisible;
+        set { _isEditorVisible = value; OnPropertyChanged(); }
+    }
+
+    private string _editorTitle = "Add Custom Uploader";
+    public string EditorTitle
+    {
+        get => _editorTitle;
+        set { _editorTitle = value; OnPropertyChanged(); }
+    }
+
+    private bool _isEditMode;
+    public bool IsEditMode
+    {
+        get => _isEditMode;
+        set { _isEditMode = value; OnPropertyChanged(); }
+    }
+
+    private int _editingIndex = -1;
+    public int EditingIndex
+    {
+        get => _editingIndex;
+        set { _editingIndex = value; OnPropertyChanged(); }
+    }
+
+    // Basic Information
+    private string _editorName = "";
+    public string EditorName
+    {
+        get => _editorName;
+        set { _editorName = value; HasNameError = false; OnPropertyChanged(); }
+    }
+
+    private bool _isImageUploader = true;
+    public bool IsImageUploader
+    {
+        get => _isImageUploader;
+        set { _isImageUploader = value; HasDestinationError = false; OnPropertyChanged(); }
+    }
+
+    private bool _isTextUploader;
+    public bool IsTextUploader
+    {
+        get => _isTextUploader;
+        set { _isTextUploader = value; HasDestinationError = false; OnPropertyChanged(); }
+    }
+
+    private bool _isFileUploader;
+    public bool IsFileUploader
+    {
+        get => _isFileUploader;
+        set { _isFileUploader = value; HasDestinationError = false; OnPropertyChanged(); }
+    }
+
+    private bool _isUrlShortener;
+    public bool IsUrlShortener
+    {
+        get => _isUrlShortener;
+        set { _isUrlShortener = value; HasDestinationError = false; OnPropertyChanged(); }
+    }
+
+    private bool _isUrlSharingService;
+    public bool IsUrlSharingService
+    {
+        get => _isUrlSharingService;
+        set { _isUrlSharingService = value; HasDestinationError = false; OnPropertyChanged(); }
+    }
+
+    // HTTP Request
+    private int _selectedMethodIndex = 1; // POST
+    public int SelectedMethodIndex
+    {
+        get => _selectedMethodIndex;
+        set { _selectedMethodIndex = value; OnPropertyChanged(); }
+    }
+
+    private string _requestUrl = "";
+    public string RequestUrl
+    {
+        get => _requestUrl;
+        set { _requestUrl = value; HasUrlError = false; OnPropertyChanged(); }
+    }
+
+    private ObservableCollection<KeyValuePairItem> _headers = new();
+    public ObservableCollection<KeyValuePairItem> Headers
+    {
+        get => _headers;
+        set { _headers = value; OnPropertyChanged(); }
+    }
+
+    private ObservableCollection<KeyValuePairItem> _parameters = new();
+    public ObservableCollection<KeyValuePairItem> Parameters
+    {
+        get => _parameters;
+        set { _parameters = value; OnPropertyChanged(); }
+    }
+
+    // Request Body
+    private int _selectedBodyTypeIndex = 1; // MultipartFormData
+    public int SelectedBodyTypeIndex
+    {
+        get => _selectedBodyTypeIndex;
+        set { _selectedBodyTypeIndex = value; OnPropertyChanged(); }
+    }
+
+    private string _fileFormName = "file";
+    public string FileFormName
+    {
+        get => _fileFormName;
+        set { _fileFormName = value; OnPropertyChanged(); }
+    }
+
+    private ObservableCollection<KeyValuePairItem> _arguments = new();
+    public ObservableCollection<KeyValuePairItem> Arguments
+    {
+        get => _arguments;
+        set { _arguments = value; OnPropertyChanged(); }
+    }
+
+    private string _bodyData = "";
+    public string BodyData
+    {
+        get => _bodyData;
+        set { _bodyData = value; OnPropertyChanged(); }
+    }
+
+    // Response Parsing
+    private string _urlPattern = "";
+    public string UrlPattern
+    {
+        get => _urlPattern;
+        set { _urlPattern = value; OnPropertyChanged(); }
+    }
+
+    private string _thumbnailUrlPattern = "";
+    public string ThumbnailUrlPattern
+    {
+        get => _thumbnailUrlPattern;
+        set { _thumbnailUrlPattern = value; OnPropertyChanged(); }
+    }
+
+    private string _deletionUrlPattern = "";
+    public string DeletionUrlPattern
+    {
+        get => _deletionUrlPattern;
+        set { _deletionUrlPattern = value; OnPropertyChanged(); }
+    }
+
+    private string _errorMessagePattern = "";
+    public string ErrorMessagePattern
+    {
+        get => _errorMessagePattern;
+        set { _errorMessagePattern = value; OnPropertyChanged(); }
+    }
+
+    // Import JSON
+    private string _jsonInput = "";
+    public string JsonInput
+    {
+        get => _jsonInput;
+        set { _jsonInput = value; OnPropertyChanged(); }
+    }
+
+    // Validation Errors
+    private bool _hasNameError;
+    public bool HasNameError
+    {
+        get => _hasNameError;
+        set { _hasNameError = value; OnPropertyChanged(); }
+    }
+
+    private bool _hasUrlError;
+    public bool HasUrlError
+    {
+        get => _hasUrlError;
+        set { _hasUrlError = value; OnPropertyChanged(); }
+    }
+
+    private bool _hasDestinationError;
+    public bool HasDestinationError
+    {
+        get => _hasDestinationError;
+        set { _hasDestinationError = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Set by the view to scroll to the first validation error field.
+    /// </summary>
+    public Action? ScrollToFirstError { get; set; }
+
+    #endregion
+
+    #region Commands
+
+    // List view commands
+    public ICommand AddNewCommand { get; }
+    public ICommand EditSelectedCommand { get; }
+    public ICommand SetActiveCommand { get; }
+    public ICommand RemoveSelectedCommand { get; }
+    public ICommand SaveCommand { get; }
+    public ICommand TestCommand { get; }
+
+    // Editor commands
+    public ICommand SaveEditorCommand { get; }
+    public ICommand CancelEditorCommand { get; }
+    public ICommand ImportJsonCommand { get; }
+    public ICommand AddHeaderCommand { get; }
+    public ICommand RemoveHeaderCommand { get; }
+    public ICommand AddParameterCommand { get; }
+    public ICommand RemoveParameterCommand { get; }
+    public ICommand AddArgumentCommand { get; }
+    public ICommand RemoveArgumentCommand { get; }
+
+    #endregion
+
+    public MobileCustomUploaderConfigViewModel()
+    {
+        // List commands
+        AddNewCommand = new RelayCommand(_ => ShowAddNew());
+        EditSelectedCommand = new RelayCommand(_ => ShowEditSelected());
+        SetActiveCommand = new RelayCommand(_ => SetActive());
+        RemoveSelectedCommand = new RelayCommand(_ => RemoveSelected());
+        SaveCommand = new RelayCommand(_ => SaveConfig());
+        TestCommand = new RelayCommand(async _ => await TestConfigAsync());
+
+        // Editor commands
+        SaveEditorCommand = new RelayCommand(_ => SaveFromEditor());
+        CancelEditorCommand = new RelayCommand(_ => CancelEditor());
+        ImportJsonCommand = new RelayCommand(_ => ImportJson());
+        AddHeaderCommand = new RelayCommand(_ => AddKeyValueItem(Headers));
+        RemoveHeaderCommand = new RelayCommand<KeyValuePairItem>(item => { if (item != null) Headers.Remove(item); });
+        AddParameterCommand = new RelayCommand(_ => AddKeyValueItem(Parameters));
+        RemoveParameterCommand = new RelayCommand<KeyValuePairItem>(item => { if (item != null) Parameters.Remove(item); });
+        AddArgumentCommand = new RelayCommand(_ => AddKeyValueItem(Arguments));
+        RemoveArgumentCommand = new RelayCommand<KeyValuePairItem>(item => { if (item != null) Arguments.Remove(item); });
+
+        LoadConfig();
+    }
+
+    #region IMobileUploaderConfig Implementation
+
+    public void LoadConfig()
+    {
+        try
+        {
+            var list = SettingsManager.UploadersConfig?.CustomUploadersList;
+            var activeIndex = SettingsManager.UploadersConfig?.CustomImageUploaderSelected ?? -1;
+
+            var items = new ObservableCollection<CustomUploaderListItem>();
+
+            if (list != null)
+            {
+                for (int i = 0; i < list.Count; i++)
+                {
+                    var item = list[i];
+                    items.Add(new CustomUploaderListItem
+                    {
+                        Name = item.ToString(),
+                        HostName = URLHelpers.GetHostName(item.RequestURL) ?? item.RequestURL,
+                        Index = i,
+                        IsActive = i == activeIndex
+                    });
+                }
+            }
+
+            CustomUploaders = items;
+            UpdateIsConfigured();
+        }
+        catch (Exception ex)
+        {
+            DebugHelper.WriteException(ex, "[MobileCustomUploaderConfig] LoadConfig failed");
+        }
+    }
+
+    public bool SaveConfig()
+    {
+        try
+        {
+            SettingsManager.SaveUploadersConfig();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            DebugHelper.WriteException(ex, "[MobileCustomUploaderConfig] SaveConfig failed");
+            return false;
+        }
+    }
+
+    public async Task<bool> TestConfigAsync()
+    {
+        IsTesting = true;
+
+        try
+        {
+            await Task.Delay(300);
+
+            var list = SettingsManager.UploadersConfig?.CustomUploadersList;
+            var activeIndex = SettingsManager.UploadersConfig?.CustomImageUploaderSelected ?? -1;
+
+            if (list == null || activeIndex < 0 || activeIndex >= list.Count)
+            {
+                IsTesting = false;
+                return false;
+            }
+
+            var item = list[activeIndex];
+            var validationError = CustomUploaderRepository.ValidateItem(item);
+            if (validationError != null)
+            {
+                IsTesting = false;
+                return false;
+            }
+
+            IsTesting = false;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            DebugHelper.WriteException(ex, "[MobileCustomUploaderConfig] TestConfig failed");
+            IsTesting = false;
+            return false;
+        }
+    }
+
+    #endregion
+
+    #region Editor Methods
+
+    private void ShowAddNew()
+    {
+        ResetEditor();
+        EditorTitle = "Add Custom Uploader";
+        IsEditMode = false;
+        EditingIndex = -1;
+        IsEditorVisible = true;
+    }
+
+    private void ShowEditSelected()
+    {
+        if (SelectedUploaderIndex < 0 || SelectedUploaderIndex >= CustomUploaders.Count)
+            return;
+
+        var listItem = CustomUploaders[SelectedUploaderIndex];
+        var config = SettingsManager.UploadersConfig;
+        if (config == null) return;
+
+        var itemIndex = listItem.Index;
+        if (itemIndex < 0 || itemIndex >= config.CustomUploadersList.Count) return;
+
+        var item = config.CustomUploadersList[itemIndex];
+        LoadItemIntoEditor(item);
+        EditorTitle = $"Edit: {item}";
+        IsEditMode = true;
+        EditingIndex = itemIndex;
+        IsEditorVisible = true;
+    }
+
+    private void ResetEditor()
+    {
+        EditorName = "";
+        IsImageUploader = true;
+        IsTextUploader = false;
+        IsFileUploader = false;
+        IsUrlShortener = false;
+        IsUrlSharingService = false;
+        SelectedMethodIndex = 1; // POST
+        RequestUrl = "";
+        Headers = new ObservableCollection<KeyValuePairItem>();
+        Parameters = new ObservableCollection<KeyValuePairItem>();
+        SelectedBodyTypeIndex = 1; // MultipartFormData
+        FileFormName = "file";
+        Arguments = new ObservableCollection<KeyValuePairItem>();
+        BodyData = "";
+        UrlPattern = "";
+        ThumbnailUrlPattern = "";
+        DeletionUrlPattern = "";
+        ErrorMessagePattern = "";
+        JsonInput = "";
+        HasNameError = false;
+        HasUrlError = false;
+        HasDestinationError = false;
+    }
+
+    private void LoadItemIntoEditor(CustomUploaderItem item)
+    {
+        EditorName = item.Name;
+
+        // Destination type flags
+        IsImageUploader = item.DestinationType.HasFlag(CustomUploaderDestinationType.ImageUploader);
+        IsTextUploader = item.DestinationType.HasFlag(CustomUploaderDestinationType.TextUploader);
+        IsFileUploader = item.DestinationType.HasFlag(CustomUploaderDestinationType.FileUploader);
+        IsUrlShortener = item.DestinationType.HasFlag(CustomUploaderDestinationType.URLShortener);
+        IsUrlSharingService = item.DestinationType.HasFlag(CustomUploaderDestinationType.URLSharingService);
+
+        // HTTP method
+        SelectedMethodIndex = (int)item.RequestMethod;
+        RequestUrl = item.RequestURL;
+
+        // Headers
+        var headers = new ObservableCollection<KeyValuePairItem>();
+        if (item.Headers != null)
+        {
+            foreach (var kvp in item.Headers)
+                headers.Add(CreateKeyValueItem(kvp.Key, kvp.Value, headers));
+        }
+        Headers = headers;
+
+        // Parameters
+        var parameters = new ObservableCollection<KeyValuePairItem>();
+        if (item.Parameters != null)
+        {
+            foreach (var kvp in item.Parameters)
+                parameters.Add(CreateKeyValueItem(kvp.Key, kvp.Value, parameters));
+        }
+        Parameters = parameters;
+
+        // Body
+        SelectedBodyTypeIndex = (int)item.Body;
+        FileFormName = string.IsNullOrEmpty(item.FileFormName) ? "file" : item.FileFormName;
+
+        // Arguments
+        var arguments = new ObservableCollection<KeyValuePairItem>();
+        if (item.Arguments != null)
+        {
+            foreach (var kvp in item.Arguments)
+                arguments.Add(CreateKeyValueItem(kvp.Key, kvp.Value, arguments));
+        }
+        Arguments = arguments;
+
+        BodyData = item.Data;
+
+        // Response parsing
+        UrlPattern = item.URL;
+        ThumbnailUrlPattern = item.ThumbnailURL;
+        DeletionUrlPattern = item.DeletionURL;
+        ErrorMessagePattern = item.ErrorMessage;
+
+        JsonInput = "";
+    }
+
+    private CustomUploaderItem BuildItemFromEditor()
+    {
+        var item = CustomUploaderItem.Init();
+
+        item.Name = EditorName?.Trim() ?? "";
+        item.RequestURL = RequestUrl?.Trim() ?? "";
+        item.RequestMethod = (XerahS.Uploaders.HttpMethod)SelectedMethodIndex;
+        item.Body = (CustomUploaderBody)SelectedBodyTypeIndex;
+        item.FileFormName = FileFormName?.Trim() ?? "";
+        item.Data = BodyData?.Trim() ?? "";
+
+        // Destination type
+        var destType = CustomUploaderDestinationType.None;
+        if (IsImageUploader) destType |= CustomUploaderDestinationType.ImageUploader;
+        if (IsTextUploader) destType |= CustomUploaderDestinationType.TextUploader;
+        if (IsFileUploader) destType |= CustomUploaderDestinationType.FileUploader;
+        if (IsUrlShortener) destType |= CustomUploaderDestinationType.URLShortener;
+        if (IsUrlSharingService) destType |= CustomUploaderDestinationType.URLSharingService;
+        item.DestinationType = destType;
+
+        // Headers
+        var headers = new Dictionary<string, string>();
+        foreach (var h in Headers)
+        {
+            if (!string.IsNullOrWhiteSpace(h.Key))
+                headers[h.Key] = h.Value ?? "";
+        }
+        item.Headers = headers.Count > 0 ? headers : null;
+
+        // Parameters
+        var parameters = new Dictionary<string, string>();
+        foreach (var p in Parameters)
+        {
+            if (!string.IsNullOrWhiteSpace(p.Key))
+                parameters[p.Key] = p.Value ?? "";
+        }
+        item.Parameters = parameters.Count > 0 ? parameters : null;
+
+        // Arguments
+        var arguments = new Dictionary<string, string>();
+        foreach (var a in Arguments)
+        {
+            if (!string.IsNullOrWhiteSpace(a.Key))
+                arguments[a.Key] = a.Value ?? "";
+        }
+        item.Arguments = arguments.Count > 0 ? arguments : null;
+
+        // Response parsing
+        item.URL = UrlPattern?.Trim() ?? "";
+        item.ThumbnailURL = ThumbnailUrlPattern?.Trim() ?? "";
+        item.DeletionURL = DeletionUrlPattern?.Trim() ?? "";
+        item.ErrorMessage = ErrorMessagePattern?.Trim() ?? "";
+
+        return item;
+    }
+
+    private bool ValidateEditor()
+    {
+        bool valid = true;
+
+        if (string.IsNullOrWhiteSpace(EditorName))
+        {
+            HasNameError = true;
+            valid = false;
+        }
+
+        if (string.IsNullOrWhiteSpace(RequestUrl))
+        {
+            HasUrlError = true;
+            valid = false;
+        }
+
+        if (!IsImageUploader && !IsTextUploader && !IsFileUploader && !IsUrlShortener && !IsUrlSharingService)
+        {
+            HasDestinationError = true;
+            valid = false;
+        }
+
+        return valid;
+    }
+
+    private void SaveFromEditor()
+    {
+        if (!ValidateEditor())
+        {
+            ScrollToFirstError?.Invoke();
+            return;
+        }
+
+        try
+        {
+            var item = BuildItemFromEditor();
+            var config = SettingsManager.UploadersConfig;
+            if (config == null) return;
+
+            var pluginsFolder = PathsManager.PluginsFolder;
+            if (!Directory.Exists(pluginsFolder))
+                Directory.CreateDirectory(pluginsFolder);
+
+            if (IsEditMode && EditingIndex >= 0 && EditingIndex < config.CustomUploadersList.Count)
+            {
+                // Update existing
+                var oldItem = config.CustomUploadersList[EditingIndex];
+                config.CustomUploadersList[EditingIndex] = item;
+
+                // Update the .sxcu file
+                var sxcuFiles = Directory.Exists(pluginsFolder)
+                    ? Directory.GetFiles(pluginsFolder, "*.sxcu")
+                    : Array.Empty<string>();
+
+                string? filePath = null;
+                foreach (var file in sxcuFiles)
+                {
+                    var loaded = CustomUploaderRepository.LoadFromFile(file);
+                    if (loaded.IsValid && loaded.Item.Name == oldItem.Name && loaded.Item.RequestURL == oldItem.RequestURL)
+                    {
+                        filePath = file;
+                        break;
+                    }
+                }
+
+                if (filePath != null)
+                {
+                    CustomUploaderRepository.SaveToFile(item, filePath);
+                }
+                else
+                {
+                    filePath = Path.Combine(pluginsFolder, item.GetFileName());
+                    CustomUploaderRepository.SaveToFile(item, filePath);
+                }
+
+                // Re-activate if this was the active uploader
+                if (EditingIndex == config.CustomImageUploaderSelected)
+                {
+                    ActivateCustomUploader(item, filePath, EditingIndex);
+                }
+            }
+            else
+            {
+                // Add new
+                config.CustomUploadersList.Add(item);
+
+                var fileName = item.GetFileName();
+                var filePath = Path.Combine(pluginsFolder, fileName);
+
+                int suffix = 1;
+                while (File.Exists(filePath))
+                {
+                    filePath = Path.Combine(pluginsFolder, Path.GetFileNameWithoutExtension(fileName) + $"_{suffix}" + Path.GetExtension(fileName));
+                    suffix++;
+                }
+
+                CustomUploaderRepository.SaveToFile(item, filePath);
+
+                // Auto-select if this is the first custom uploader
+                if (config.CustomUploadersList.Count == 1)
+                {
+                    config.CustomImageUploaderSelected = 0;
+                    ActivateCustomUploader(item, filePath, 0);
+                }
+            }
+
+            SettingsManager.SaveUploadersConfig();
+            IsEditorVisible = false;
+            LoadConfig();
+        }
+        catch (Exception ex)
+        {
+            DebugHelper.WriteException(ex, "[MobileCustomUploaderConfig] SaveFromEditor failed");
+        }
+    }
+
+    private void CancelEditor()
+    {
+        IsEditorVisible = false;
+    }
+
+    private void ImportJson()
+    {
+        if (string.IsNullOrWhiteSpace(JsonInput))
+            return;
+
+        try
+        {
+            var loaded = CustomUploaderRepository.LoadFromJson(JsonInput);
+            if (!loaded.IsValid)
+                return;
+
+            LoadItemIntoEditor(loaded.Item);
+            JsonInput = "";
+        }
+        catch (Exception ex)
+        {
+            DebugHelper.WriteException(ex, "[MobileCustomUploaderConfig] ImportJson failed");
+        }
+    }
+
+    #endregion
+
+    #region List Management
+
+    private void SetActive()
+    {
+        if (SelectedUploaderIndex < 0 || SelectedUploaderIndex >= CustomUploaders.Count)
+            return;
+
+        try
+        {
+            var listItem = CustomUploaders[SelectedUploaderIndex];
+            var config = SettingsManager.UploadersConfig;
+            if (config == null) return;
+
+            var itemIndex = listItem.Index;
+            if (itemIndex < 0 || itemIndex >= config.CustomUploadersList.Count) return;
+
+            var item = config.CustomUploadersList[itemIndex];
+            config.CustomImageUploaderSelected = itemIndex;
+
+            // Find the .sxcu file for this uploader
+            var pluginsFolder = PathsManager.PluginsFolder;
+            var sxcuFiles = Directory.Exists(pluginsFolder)
+                ? Directory.GetFiles(pluginsFolder, "*.sxcu")
+                : Array.Empty<string>();
+
+            string? filePath = null;
+            foreach (var file in sxcuFiles)
+            {
+                var loaded = CustomUploaderRepository.LoadFromFile(file);
+                if (loaded.IsValid && loaded.Item.Name == item.Name && loaded.Item.RequestURL == item.RequestURL)
+                {
+                    filePath = file;
+                    break;
+                }
+            }
+
+            // If no .sxcu file found, save one
+            if (filePath == null)
+            {
+                if (!Directory.Exists(pluginsFolder))
+                    Directory.CreateDirectory(pluginsFolder);
+                filePath = Path.Combine(pluginsFolder, item.GetFileName());
+                CustomUploaderRepository.SaveToFile(item, filePath);
+            }
+
+            ActivateCustomUploader(item, filePath, itemIndex);
+            SettingsManager.SaveUploadersConfig();
+            LoadConfig();
+        }
+        catch (Exception ex)
+        {
+            DebugHelper.WriteException(ex, "[MobileCustomUploaderConfig] SetActive failed");
+        }
+    }
+
+    private void ActivateCustomUploader(CustomUploaderItem item, string filePath, int index)
+    {
+        try
+        {
+            // Register provider in catalog
+            var loadedUploader = new LoadedCustomUploader(item, filePath);
+            var provider = new CustomUploaderProvider(loadedUploader);
+            ProviderCatalog.RegisterProvider(provider);
+
+            // Create or find instance in InstanceManager
+            var instanceManager = InstanceManager.Instance;
+            var existingInstances = instanceManager.GetInstancesByCategory(UploaderCategory.Image);
+            var existing = existingInstances.FirstOrDefault(i => i.ProviderId == provider.ProviderId);
+
+            if (existing == null)
+            {
+                var instance = new UploaderInstance
+                {
+                    ProviderId = provider.ProviderId,
+                    Category = UploaderCategory.Image,
+                    DisplayName = item.ToString(),
+                    SettingsJson = provider.GetDefaultSettings(UploaderCategory.Image)
+                };
+                instanceManager.AddInstance(instance);
+                existing = instanceManager.GetInstancesByCategory(UploaderCategory.Image)
+                    .FirstOrDefault(i => i.ProviderId == provider.ProviderId);
+            }
+
+            if (existing != null)
+            {
+                instanceManager.SetDefaultInstance(UploaderCategory.Image, existing.InstanceId);
+                SettingsManager.DefaultTaskSettings.DestinationInstanceId = existing.InstanceId;
+                SettingsManager.SaveWorkflowsConfig();
+            }
+        }
+        catch (Exception ex)
+        {
+            DebugHelper.WriteException(ex, "[MobileCustomUploaderConfig] ActivateCustomUploader failed");
+        }
+    }
+
+    private void RemoveSelected()
+    {
+        if (SelectedUploaderIndex < 0 || SelectedUploaderIndex >= CustomUploaders.Count)
+            return;
+
+        try
+        {
+            var listItem = CustomUploaders[SelectedUploaderIndex];
+            var config = SettingsManager.UploadersConfig;
+            if (config == null) return;
+
+            var itemIndex = listItem.Index;
+            if (itemIndex < 0 || itemIndex >= config.CustomUploadersList.Count) return;
+
+            var item = config.CustomUploadersList[itemIndex];
+            var wasActive = itemIndex == config.CustomImageUploaderSelected;
+
+            // Remove from list
+            config.CustomUploadersList.RemoveAt(itemIndex);
+
+            // Try to delete the .sxcu file
+            var pluginsFolder = PathsManager.PluginsFolder;
+            if (Directory.Exists(pluginsFolder))
+            {
+                foreach (var file in Directory.GetFiles(pluginsFolder, "*.sxcu"))
+                {
+                    var loaded = CustomUploaderRepository.LoadFromFile(file);
+                    if (loaded.IsValid && loaded.Item.Name == item.Name && loaded.Item.RequestURL == item.RequestURL)
+                    {
+                        try { File.Delete(file); } catch { }
+                        CustomUploaderRepository.RemoveFile(file);
+                        break;
+                    }
+                }
+            }
+
+            // Adjust selected index
+            if (config.CustomUploadersList.Count == 0)
+            {
+                config.CustomImageUploaderSelected = 0;
+            }
+            else if (itemIndex <= config.CustomImageUploaderSelected)
+            {
+                config.CustomImageUploaderSelected = Math.Max(0, config.CustomImageUploaderSelected - 1);
+            }
+
+            // If the removed uploader was active, clear the destination
+            if (wasActive)
+            {
+                SettingsManager.DefaultTaskSettings.DestinationInstanceId = null;
+                SettingsManager.SaveWorkflowsConfig();
+            }
+
+            SettingsManager.SaveUploadersConfig();
+            LoadConfig();
+        }
+        catch (Exception ex)
+        {
+            DebugHelper.WriteException(ex, "[MobileCustomUploaderConfig] RemoveSelected failed");
+        }
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    private void UpdateIsConfigured()
+    {
+        var list = SettingsManager.UploadersConfig?.CustomUploadersList;
+        var activeIndex = SettingsManager.UploadersConfig?.CustomImageUploaderSelected ?? -1;
+        IsConfigured = list != null && list.Count > 0 && activeIndex >= 0 && activeIndex < list.Count;
+        OnPropertyChanged(nameof(ActiveUploaderName));
+    }
+
+    private void AddKeyValueItem(ObservableCollection<KeyValuePairItem> collection)
+    {
+        KeyValuePairItem? item = null;
+        item = new KeyValuePairItem
+        {
+            RemoveCommand = new RelayCommand(_ => collection.Remove(item!))
+        };
+        collection.Add(item);
+    }
+
+    private KeyValuePairItem CreateKeyValueItem(string key, string value, ObservableCollection<KeyValuePairItem> collection)
+    {
+        var item = new KeyValuePairItem { Key = key, Value = value };
+        item.RemoveCommand = new RelayCommand(_ => collection.Remove(item));
+        return item;
+    }
+
+    protected void OnPropertyChanged([CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
+    #endregion
+}

--- a/src/XerahS.Mobile.UI/ViewModels/MobileSettingsViewModel.cs
+++ b/src/XerahS.Mobile.UI/ViewModels/MobileSettingsViewModel.cs
@@ -87,6 +87,7 @@ public class MobileSettingsViewModel : INotifyPropertyChanged
     public string CurrentViewTitle => CurrentView?.GetType().Name switch
     {
         "MobileAmazonS3ConfigView" => "Amazon S3",
+        "MobileCustomUploaderConfigView" => "Custom Uploader",
         _ => "Settings"
     };
 
@@ -124,6 +125,17 @@ public class MobileSettingsViewModel : INotifyPropertyChanged
         // var dropboxVm = new MobileDropboxConfigViewModel();
         // items.Add(new SettingsItem { ... });
 
+        // Custom Uploader - add/manage custom image uploaders via .sxcu JSON
+        var customVm = new MobileCustomUploaderConfigViewModel();
+        items.Add(new SettingsItem
+        {
+            Title = customVm.UploaderName,
+            Description = customVm.Description,
+            IconPath = customVm.IconPath,
+            IsConfigured = customVm.IsConfigured,
+            CreateView = () => new MobileCustomUploaderConfigView()
+        });
+
         SettingsItems = new ObservableCollection<SettingsItem>(items);
     }
 
@@ -135,6 +147,12 @@ public class MobileSettingsViewModel : INotifyPropertyChanged
             if (item.Title == "Amazon S3")
             {
                 var vm = new MobileAmazonS3ConfigViewModel();
+                item.IsConfigured = vm.IsConfigured;
+                item.Description = vm.Description;
+            }
+            else if (item.Title == "Custom Uploader")
+            {
+                var vm = new MobileCustomUploaderConfigViewModel();
                 item.IsConfigured = vm.IsConfigured;
                 item.Description = vm.Description;
             }

--- a/src/XerahS.Mobile.UI/ViewModels/MobileUploadViewModel.cs
+++ b/src/XerahS.Mobile.UI/ViewModels/MobileUploadViewModel.cs
@@ -133,7 +133,8 @@ public class MobileUploadViewModel : INotifyPropertyChanged
             FileName = fileName,
             Success = success,
             Url = url,
-            Error = error
+            Error = error,
+            CopyUrlCommand = CopyUrlCommand
         });
 
         _pendingCount--;
@@ -173,6 +174,7 @@ public class UploadResultItem
     public string? Url { get; set; }
     public string? Error { get; set; }
     public bool HasUrl => !string.IsNullOrEmpty(Url);
+    public ICommand? CopyUrlCommand { get; set; }
 }
 
 internal class RelayCommand<T> : ICommand

--- a/src/XerahS.Mobile.UI/Views/MobileCustomUploaderConfigView.axaml
+++ b/src/XerahS.Mobile.UI/Views/MobileCustomUploaderConfigView.axaml
@@ -1,0 +1,553 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:XerahS.Mobile.UI.ViewModels"
+             x:Class="XerahS.Mobile.UI.Views.MobileCustomUploaderConfigView"
+             x:DataType="vm:MobileCustomUploaderConfigViewModel"
+             x:Name="RootView">
+
+    <Grid>
+        <!-- State 1: List View -->
+        <ScrollViewer IsVisible="{Binding !IsEditorVisible}">
+            <StackPanel Margin="16" Spacing="16">
+
+                <!-- Header Card -->
+                <Border Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
+                        CornerRadius="12"
+                        Padding="20">
+                    <StackPanel Spacing="6">
+                        <TextBlock Text="Custom Uploader"
+                                   FontSize="22"
+                                   FontWeight="Bold"/>
+                        <TextBlock Text="Add and manage custom HTTP uploaders"
+                                   FontSize="13"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                   TextWrapping="Wrap"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- Configured Uploaders Card -->
+                <Border Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
+                        CornerRadius="12"
+                        Padding="16">
+                    <StackPanel Spacing="12">
+                        <TextBlock Text="Configured Uploaders"
+                                   FontWeight="SemiBold"
+                                   FontSize="15"
+                                   Margin="4,0,0,0"/>
+
+                        <ListBox ItemsSource="{Binding CustomUploaders}"
+                                 SelectedIndex="{Binding SelectedUploaderIndex}"
+                                 MinHeight="60"
+                                 MaxHeight="280"
+                                 CornerRadius="8"
+                                 Padding="0">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate x:DataType="vm:CustomUploaderListItem">
+                                    <Grid ColumnDefinitions="Auto,*,Auto" Margin="4,6">
+                                        <!-- Icon circle -->
+                                        <Border Grid.Column="0"
+                                                Width="36" Height="36"
+                                                CornerRadius="18"
+                                                Background="{DynamicResource SystemAccentColor}"
+                                                Margin="0,0,12,0"
+                                                VerticalAlignment="Center">
+                                            <TextBlock Text="☁"
+                                                       FontSize="18"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center"
+                                                       Foreground="White"/>
+                                        </Border>
+
+                                        <!-- Name and host -->
+                                        <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                            <TextBlock Text="{Binding Name}"
+                                                       FontWeight="SemiBold"
+                                                       FontSize="14"/>
+                                            <TextBlock Text="{Binding HostName}"
+                                                       FontSize="12"
+                                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                                        </StackPanel>
+
+                                        <!-- Active badge -->
+                                        <Border Grid.Column="2"
+                                                IsVisible="{Binding IsActive}"
+                                                CornerRadius="10"
+                                                Background="#1A4CAF50"
+                                                Padding="10,4"
+                                                VerticalAlignment="Center">
+                                            <TextBlock Text="ACTIVE"
+                                                       FontSize="10"
+                                                       FontWeight="Bold"
+                                                       Foreground="#4CAF50"/>
+                                        </Border>
+                                    </Grid>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+
+                        <!-- Empty state -->
+                        <Border IsVisible="{Binding !CustomUploaders.Count}"
+                                CornerRadius="8"
+                                BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                BorderThickness="1"
+                                Opacity="0.4"
+                                Padding="20"
+                                HorizontalAlignment="Stretch">
+                            <StackPanel HorizontalAlignment="Center" Spacing="6">
+                                <TextBlock Text="☁"
+                                           FontSize="28"
+                                           HorizontalAlignment="Center"
+                                           Opacity="0.5"/>
+                                <TextBlock Text="No custom uploaders configured yet"
+                                           FontSize="13"
+                                           FontStyle="Italic"
+                                           HorizontalAlignment="Center"
+                                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+                </Border>
+
+                <!-- Action Buttons -->
+                <StackPanel Spacing="10">
+                    <Button Content="Add New Uploader"
+                            Command="{Binding AddNewCommand}"
+                            HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Center"
+                            VerticalContentAlignment="Center"
+                            Height="48"
+                            CornerRadius="10"
+                            Classes="accent"
+                            FontWeight="SemiBold"
+                            FontSize="15"/>
+
+                    <Grid ColumnDefinitions="*,*,*" ColumnSpacing="8">
+                        <Button Grid.Column="0"
+                                Content="Edit"
+                                Command="{Binding EditSelectedCommand}"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Center"
+                                VerticalContentAlignment="Center"
+                                Height="42"
+                                CornerRadius="10"
+                                FontSize="13"/>
+                        <Button Grid.Column="1"
+                                Content="Set Active"
+                                Command="{Binding SetActiveCommand}"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Center"
+                                VerticalContentAlignment="Center"
+                                Height="42"
+                                CornerRadius="10"
+                                FontSize="13"/>
+                        <Button Grid.Column="2"
+                                Content="Remove"
+                                Command="{Binding RemoveSelectedCommand}"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Center"
+                                VerticalContentAlignment="Center"
+                                Height="42"
+                                CornerRadius="10"
+                                FontSize="13"/>
+                    </Grid>
+                </StackPanel>
+
+                <!-- Progress -->
+                <ProgressBar IsIndeterminate="True"
+                             IsVisible="{Binding IsTesting}"
+                             CornerRadius="4"
+                             Margin="0,4"/>
+
+            </StackPanel>
+        </ScrollViewer>
+
+        <!-- State 2: Editor Form -->
+        <ScrollViewer IsVisible="{Binding IsEditorVisible}"
+                      x:Name="EditorScrollViewer">
+            <StackPanel Margin="16" Spacing="14">
+
+                <!-- Editor Title -->
+                <TextBlock Text="{Binding EditorTitle}"
+                           FontSize="22"
+                           FontWeight="Bold"
+                           Margin="4,4,0,0"/>
+
+                <!-- Section: Basic Information -->
+                <Border x:Name="BasicInfoSection"
+                        Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
+                        CornerRadius="12"
+                        Padding="16">
+                    <StackPanel Spacing="14">
+                        <TextBlock Text="Basic Information"
+                                   FontWeight="SemiBold"
+                                   FontSize="15"
+                                   Opacity="0.7"/>
+
+                        <StackPanel Spacing="4">
+                            <TextBlock Text="Name" FontSize="13" FontWeight="SemiBold"/>
+                            <Grid>
+                                <TextBox Text="{Binding EditorName, Mode=TwoWay}"
+                                         Watermark="My Custom Uploader"
+                                         CornerRadius="8"/>
+                                <Border BorderBrush="#FF6B6B"
+                                        BorderThickness="2"
+                                        CornerRadius="8"
+                                        IsVisible="{Binding HasNameError}"
+                                        IsHitTestVisible="False"/>
+                            </Grid>
+                        </StackPanel>
+
+                        <StackPanel Spacing="6">
+                            <TextBlock Text="Destination Types" FontSize="13" FontWeight="SemiBold"/>
+                            <WrapPanel Orientation="Horizontal">
+                                <CheckBox Content="Image" IsChecked="{Binding IsImageUploader}" Margin="0,0,14,6"/>
+                                <CheckBox Content="Text" IsChecked="{Binding IsTextUploader}" Margin="0,0,14,6"/>
+                                <CheckBox Content="File" IsChecked="{Binding IsFileUploader}" Margin="0,0,14,6"/>
+                                <CheckBox Content="URL Shortener" IsChecked="{Binding IsUrlShortener}" Margin="0,0,14,6"/>
+                                <CheckBox Content="URL Sharing" IsChecked="{Binding IsUrlSharingService}" Margin="0,0,0,6"/>
+                            </WrapPanel>
+                            <TextBlock Text="Select at least one destination type"
+                                       FontSize="12"
+                                       Foreground="#FF6B6B"
+                                       IsVisible="{Binding HasDestinationError}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+
+                <!-- Section: HTTP Request -->
+                <Border x:Name="HttpRequestSection"
+                        Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
+                        CornerRadius="12"
+                        Padding="16">
+                    <StackPanel Spacing="14">
+                        <TextBlock Text="HTTP Request"
+                                   FontWeight="SemiBold"
+                                   FontSize="15"
+                                   Opacity="0.7"/>
+
+                        <Grid ColumnDefinitions="100,*" ColumnSpacing="10">
+                            <StackPanel Grid.Column="0" Spacing="4">
+                                <TextBlock Text="Method" FontSize="13" FontWeight="SemiBold"/>
+                                <ComboBox ItemsSource="{Binding HttpMethods}"
+                                          SelectedIndex="{Binding SelectedMethodIndex}"
+                                          HorizontalAlignment="Stretch"
+                                          CornerRadius="8"/>
+                            </StackPanel>
+                            <StackPanel Grid.Column="1" Spacing="4">
+                                <TextBlock Text="Request URL" FontSize="13" FontWeight="SemiBold"/>
+                                <Grid>
+                                    <TextBox Text="{Binding RequestUrl, Mode=TwoWay}"
+                                             Watermark="https://example.com/api/upload"
+                                             CornerRadius="8"/>
+                                    <Border BorderBrush="#FF6B6B"
+                                            BorderThickness="2"
+                                            CornerRadius="8"
+                                            IsVisible="{Binding HasUrlError}"
+                                            IsHitTestVisible="False"/>
+                                </Grid>
+                            </StackPanel>
+                        </Grid>
+
+                        <!-- Headers -->
+                        <StackPanel Spacing="8">
+                            <Grid ColumnDefinitions="*,Auto">
+                                <TextBlock Grid.Column="0" Text="Headers" FontSize="13" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                <Button Grid.Column="1"
+                                        Content="+ Add"
+                                        Command="{Binding AddHeaderCommand}"
+                                        Padding="12,4"
+                                        FontSize="12"
+                                        CornerRadius="6"
+                                        VerticalContentAlignment="Center"
+                                        Height="28"/>
+                            </Grid>
+                            <ItemsControl ItemsSource="{Binding Headers}"
+                                          x:Name="HeadersList">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:KeyValuePairItem">
+                                        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
+                                                CornerRadius="8"
+                                                Padding="8"
+                                                Margin="0,2">
+                                            <Grid ColumnDefinitions="*,*,Auto" ColumnSpacing="6">
+                                                <TextBox Grid.Column="0"
+                                                         Text="{Binding Key, Mode=TwoWay}"
+                                                         Watermark="Key"
+                                                         CornerRadius="6"
+                                                         FontSize="13"/>
+                                                <TextBox Grid.Column="1"
+                                                         Text="{Binding Value, Mode=TwoWay}"
+                                                         Watermark="Value"
+                                                         CornerRadius="6"
+                                                         FontSize="13"/>
+                                                <Button Grid.Column="2"
+                                                        Content="✕"
+                                                        Command="{Binding RemoveCommand}"
+                                                        Width="30" Height="30"
+                                                        Padding="0"
+                                                        CornerRadius="6"
+                                                        FontSize="12"
+                                                        HorizontalContentAlignment="Center"
+                                                        VerticalContentAlignment="Center"
+                                                        Foreground="#FF6B6B"/>
+                                            </Grid>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+
+                        <!-- URL Parameters -->
+                        <StackPanel Spacing="8">
+                            <Grid ColumnDefinitions="*,Auto">
+                                <TextBlock Grid.Column="0" Text="URL Parameters" FontSize="13" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                <Button Grid.Column="1"
+                                        Content="+ Add"
+                                        Command="{Binding AddParameterCommand}"
+                                        Padding="12,4"
+                                        FontSize="12"
+                                        CornerRadius="6"
+                                        VerticalContentAlignment="Center"
+                                        Height="28"/>
+                            </Grid>
+                            <ItemsControl ItemsSource="{Binding Parameters}"
+                                          x:Name="ParametersList">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:KeyValuePairItem">
+                                        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
+                                                CornerRadius="8"
+                                                Padding="8"
+                                                Margin="0,2">
+                                            <Grid ColumnDefinitions="*,*,Auto" ColumnSpacing="6">
+                                                <TextBox Grid.Column="0"
+                                                         Text="{Binding Key, Mode=TwoWay}"
+                                                         Watermark="Key"
+                                                         CornerRadius="6"
+                                                         FontSize="13"/>
+                                                <TextBox Grid.Column="1"
+                                                         Text="{Binding Value, Mode=TwoWay}"
+                                                         Watermark="Value"
+                                                         CornerRadius="6"
+                                                         FontSize="13"/>
+                                                <Button Grid.Column="2"
+                                                        Content="✕"
+                                                        Command="{Binding RemoveCommand}"
+                                                        Width="30" Height="30"
+                                                        Padding="0"
+                                                        CornerRadius="6"
+                                                        FontSize="12"
+                                                        HorizontalContentAlignment="Center"
+                                                        VerticalContentAlignment="Center"
+                                                        Foreground="#FF6B6B"/>
+                                            </Grid>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+
+                <!-- Section: Request Body -->
+                <Border Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
+                        CornerRadius="12"
+                        Padding="16">
+                    <StackPanel Spacing="14">
+                        <TextBlock Text="Request Body"
+                                   FontWeight="SemiBold"
+                                   FontSize="15"
+                                   Opacity="0.7"/>
+
+                        <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+                            <StackPanel Grid.Column="0" Spacing="4">
+                                <TextBlock Text="Body Type" FontSize="13" FontWeight="SemiBold"/>
+                                <ComboBox ItemsSource="{Binding BodyTypes}"
+                                          SelectedIndex="{Binding SelectedBodyTypeIndex}"
+                                          HorizontalAlignment="Stretch"
+                                          CornerRadius="8"/>
+                            </StackPanel>
+                            <StackPanel Grid.Column="1" Spacing="4">
+                                <TextBlock Text="File Form Name" FontSize="13" FontWeight="SemiBold"/>
+                                <TextBox Text="{Binding FileFormName, Mode=TwoWay}"
+                                         Watermark="file"
+                                         CornerRadius="8"/>
+                            </StackPanel>
+                        </Grid>
+
+                        <!-- Form Arguments -->
+                        <StackPanel Spacing="8">
+                            <Grid ColumnDefinitions="*,Auto">
+                                <TextBlock Grid.Column="0" Text="Form Arguments" FontSize="13" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                <Button Grid.Column="1"
+                                        Content="+ Add"
+                                        Command="{Binding AddArgumentCommand}"
+                                        Padding="12,4"
+                                        FontSize="12"
+                                        CornerRadius="6"
+                                        VerticalContentAlignment="Center"
+                                        Height="28"/>
+                            </Grid>
+                            <ItemsControl ItemsSource="{Binding Arguments}"
+                                          x:Name="ArgumentsList">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:KeyValuePairItem">
+                                        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
+                                                CornerRadius="8"
+                                                Padding="8"
+                                                Margin="0,2">
+                                            <Grid ColumnDefinitions="*,*,Auto" ColumnSpacing="6">
+                                                <TextBox Grid.Column="0"
+                                                         Text="{Binding Key, Mode=TwoWay}"
+                                                         Watermark="Key"
+                                                         CornerRadius="6"
+                                                         FontSize="13"/>
+                                                <TextBox Grid.Column="1"
+                                                         Text="{Binding Value, Mode=TwoWay}"
+                                                         Watermark="Value"
+                                                         CornerRadius="6"
+                                                         FontSize="13"/>
+                                                <Button Grid.Column="2"
+                                                        Content="✕"
+                                                        Command="{Binding RemoveCommand}"
+                                                        Width="30" Height="30"
+                                                        Padding="0"
+                                                        CornerRadius="6"
+                                                        FontSize="12"
+                                                        HorizontalContentAlignment="Center"
+                                                        VerticalContentAlignment="Center"
+                                                        Foreground="#FF6B6B"/>
+                                            </Grid>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+
+                        <!-- Body Data -->
+                        <StackPanel Spacing="4">
+                            <TextBlock Text="Body Data (JSON/XML)" FontSize="13" FontWeight="SemiBold"/>
+                            <TextBox Text="{Binding BodyData, Mode=TwoWay}"
+                                     AcceptsReturn="True"
+                                     TextWrapping="Wrap"
+                                     MinHeight="80"
+                                     MaxHeight="150"
+                                     Watermark="JSON or XML body content"
+                                     CornerRadius="8"
+                                     FontFamily="Consolas, Monospace"
+                                     FontSize="12"/>
+                            <TextBlock Text="Use input for file content, filename for file name."
+                                       FontSize="11"
+                                       Opacity="0.5"
+                                       Margin="4,2,0,0"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+
+                <!-- Section: Response Parsing -->
+                <Border Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
+                        CornerRadius="12"
+                        Padding="16">
+                    <StackPanel Spacing="14">
+                        <StackPanel Spacing="4">
+                            <TextBlock Text="Response Parsing"
+                                       FontWeight="SemiBold"
+                                       FontSize="15"
+                                       Opacity="0.7"/>
+                            <TextBlock Text="Extract URLs from the server response using json:path, regex:pattern, or response syntax."
+                                       FontSize="11"
+                                       Opacity="0.5"
+                                       TextWrapping="Wrap"/>
+                        </StackPanel>
+
+                        <StackPanel Spacing="4">
+                            <TextBlock Text="URL" FontSize="13" FontWeight="SemiBold"/>
+                            <TextBox Text="{Binding UrlPattern, Mode=TwoWay}"
+                                     Watermark="e.g. json:url or response"
+                                     CornerRadius="8"/>
+                        </StackPanel>
+
+                        <StackPanel Spacing="4">
+                            <TextBlock Text="Thumbnail URL" FontSize="13" FontWeight="SemiBold"/>
+                            <TextBox Text="{Binding ThumbnailUrlPattern, Mode=TwoWay}"
+                                     Watermark="e.g. json:thumbnail"
+                                     CornerRadius="8"/>
+                        </StackPanel>
+
+                        <StackPanel Spacing="4">
+                            <TextBlock Text="Deletion URL" FontSize="13" FontWeight="SemiBold"/>
+                            <TextBox Text="{Binding DeletionUrlPattern, Mode=TwoWay}"
+                                     Watermark="e.g. json:delete_url"
+                                     CornerRadius="8"/>
+                        </StackPanel>
+
+                        <StackPanel Spacing="4">
+                            <TextBlock Text="Error Message" FontSize="13" FontWeight="SemiBold"/>
+                            <TextBox Text="{Binding ErrorMessagePattern, Mode=TwoWay}"
+                                     Watermark="e.g. json:error"
+                                     CornerRadius="8"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+
+                <!-- Section: Import from JSON -->
+                <Border Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
+                        CornerRadius="12"
+                        Padding="16">
+                    <StackPanel Spacing="10">
+                        <StackPanel Spacing="2">
+                            <TextBlock Text="Import from JSON"
+                                       FontWeight="SemiBold"
+                                       FontSize="15"
+                                       Opacity="0.7"/>
+                            <TextBlock Text="Paste .sxcu JSON to populate the form above"
+                                       FontSize="11"
+                                       Opacity="0.5"/>
+                        </StackPanel>
+                        <TextBox Text="{Binding JsonInput, Mode=TwoWay}"
+                                 AcceptsReturn="True"
+                                 TextWrapping="Wrap"
+                                 MinHeight="80"
+                                 MaxHeight="150"
+                                 Watermark="Paste .sxcu JSON content here..."
+                                 FontFamily="Consolas, Monospace"
+                                 FontSize="12"
+                                 CornerRadius="8"/>
+                        <Button Content="Import JSON"
+                                Command="{Binding ImportJsonCommand}"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Center"
+                                VerticalContentAlignment="Center"
+                                Height="40"
+                                CornerRadius="8"
+                                FontSize="13"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- Editor Action Buttons -->
+                <StackPanel Spacing="10" Margin="0,4,0,40">
+                    <Button Content="Save"
+                            Command="{Binding SaveEditorCommand}"
+                            HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Center"
+                            VerticalContentAlignment="Center"
+                            Height="48"
+                            CornerRadius="10"
+                            Classes="accent"
+                            FontWeight="SemiBold"
+                            FontSize="15"/>
+
+                    <Button Content="Cancel"
+                            Command="{Binding CancelEditorCommand}"
+                            HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Center"
+                            VerticalContentAlignment="Center"
+                            Height="42"
+                            CornerRadius="10"
+                            FontSize="14"/>
+                </StackPanel>
+
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+
+</UserControl>

--- a/src/XerahS.Mobile.UI/Views/MobileCustomUploaderConfigView.axaml.cs
+++ b/src/XerahS.Mobile.UI/Views/MobileCustomUploaderConfigView.axaml.cs
@@ -1,0 +1,61 @@
+#region License Information (GPL v3)
+
+/*
+    XerahS - The Avalonia UI implementation of ShareX
+    Copyright (c) 2007-2026 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using XerahS.Mobile.UI.ViewModels;
+
+namespace XerahS.Mobile.UI.Views;
+
+public partial class MobileCustomUploaderConfigView : UserControl
+{
+    public MobileCustomUploaderConfigView()
+    {
+        InitializeComponent();
+        var vm = new MobileCustomUploaderConfigViewModel();
+        vm.ScrollToFirstError = ScrollToFirstError;
+        DataContext = vm;
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private void ScrollToFirstError()
+    {
+        var vm = DataContext as MobileCustomUploaderConfigViewModel;
+        if (vm == null) return;
+
+        Control? target = null;
+
+        if (vm.HasNameError || vm.HasDestinationError)
+            target = this.FindControl<Border>("BasicInfoSection");
+        else if (vm.HasUrlError)
+            target = this.FindControl<Border>("HttpRequestSection");
+
+        target?.BringIntoView();
+    }
+}

--- a/src/XerahS.Mobile.UI/Views/MobileSettingsView.axaml
+++ b/src/XerahS.Mobile.UI/Views/MobileSettingsView.axaml
@@ -57,7 +57,7 @@
                             <TextBlock Text="Upload Destinations"
                                        FontSize="16"
                                        FontWeight="SemiBold"/>
-                            <TextBlock Text="Configure where your files will be uploaded. Currently Amazon S3 is supported."
+                            <TextBlock Text="Configure where your files will be uploaded. Amazon S3 and custom uploaders are supported."
                                        FontSize="13"
                                        TextWrapping="Wrap"
                                        Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>

--- a/src/XerahS.Mobile.UI/Views/MobileUploadView.axaml
+++ b/src/XerahS.Mobile.UI/Views/MobileUploadView.axaml
@@ -56,6 +56,7 @@
 
                 <!-- Results list -->
                 <ItemsControl ItemsSource="{Binding Results}"
+                              x:Name="ResultsList"
                               Margin="0,8">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate x:DataType="vm:UploadResultItem">
@@ -84,7 +85,7 @@
                                     <!-- Copy URL button -->
                                     <Button Content="Copy URL"
                                             IsVisible="{Binding HasUrl}"
-                                            Command="{Binding $parent[ItemsControl].((vm:MobileUploadViewModel)DataContext).CopyUrlCommand}"
+                                            Command="{Binding CopyUrlCommand}"
                                             CommandParameter="{Binding Url}"
                                             HorizontalAlignment="Left" />
 

--- a/src/XerahS.Mobile.iOS/AppDelegate.cs
+++ b/src/XerahS.Mobile.iOS/AppDelegate.cs
@@ -45,6 +45,9 @@ public partial class AppDelegate : AvaloniaAppDelegate<MobileApp>
         // Initialize platform services for mobile
         MobilePlatform.Initialize(PlatformType.iOS);
 
+        // Replace in-memory clipboard with native iOS clipboard
+        PlatformServices.Clipboard = new iOSClipboardService();
+
         // Set personal folder to app's Documents directory
         var documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
         PathsManager.PersonalFolder = documentsPath;

--- a/src/XerahS.Mobile.iOS/iOSClipboardService.cs
+++ b/src/XerahS.Mobile.iOS/iOSClipboardService.cs
@@ -1,0 +1,58 @@
+#region License Information (GPL v3)
+
+/*
+    XerahS - The Avalonia UI implementation of ShareX
+    Copyright (c) 2007-2026 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using SkiaSharp;
+using UIKit;
+using XerahS.Platform.Abstractions;
+
+namespace XerahS.Mobile.iOS;
+
+public class iOSClipboardService : IClipboardService
+{
+    public void Clear() => UIPasteboard.General.String = "";
+    public bool ContainsText() => !string.IsNullOrEmpty(UIPasteboard.General.String);
+    public bool ContainsImage() => false;
+    public bool ContainsFileDropList() => false;
+
+    public string? GetText() => UIPasteboard.General.String;
+    public void SetText(string text) => UIPasteboard.General.String = text;
+
+    public SKBitmap? GetImage() => null;
+    public void SetImage(SKBitmap image) { }
+
+    public string[]? GetFileDropList() => null;
+    public void SetFileDropList(string[] files) { }
+
+    public object? GetData(string format) => null;
+    public void SetData(string format, object data) { }
+    public bool ContainsData(string format) => false;
+
+    public Task<string?> GetTextAsync() => Task.FromResult(GetText());
+    public Task SetTextAsync(string text)
+    {
+        SetText(text);
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
Enables users to configure custom HTTP uploaders through a form-based editor.

Replaces the in-memory clipboard with the native iOS clipboard.

Includes a fix for the copy button in the upload result item.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2FShareX%2FXerahS%2Fpull%2F124&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->