### PR TITLE
Codex/xip0050 official avalonia primitives

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,6 @@
     <PackageVersion Include="CommunityToolkit.Maui" Version="14.0.0" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="FluentAvaloniaUI" Version="2.4.1" />
     <PackageVersion Include="FluentFTP" Version="53.0.2" />
     <PackageVersion Include="Material.Avalonia" Version="3.7.4" />
     <PackageVersion Include="Material.Icons.Avalonia" Version="2.1.10" />

--- a/developers/lessons-learnt/general.md
+++ b/developers/lessons-learnt/general.md
@@ -12,20 +12,20 @@ Promote only repository-wide policy changes to `AGENTS.md`.
 
 ## table of Contents
 
-1.  [UI & FluentAvalonia](#ui--fluentavalonia)
+1.  [UI & Theming](#ui--theming)
 2.  [Build & Configuration](#build--configuration)
 3.  [Plugin System](#plugin-system)
 4.  [Android / Avalonia](#android--avalonia)
 
 ---
 
-## UI & FluentAvalonia
+## UI & Theming
 
 ### ContextMenu vs. ContextFlyout
 
-**Issue**: Standard `ContextMenu` controls do not render correctly with `FluentAvaloniaTheme`. They utilize legacy Popup windows which are not fully styled by the theme and may appear unstyled or invisible.
+**Issue**: The old warning against `ContextMenu` was specific to `FluentAvaloniaTheme`. XerahS now uses the official Avalonia `FluentTheme`, so standard `ContextMenu` rendering is no longer blocked by that theme-specific limitation.
 
-**Solution**: Always use `ContextFlyout` with `MenuFlyout` instead of `ContextMenu`.
+**Solution**: Use `ContextMenu` for ordinary context menus. Keep `ContextFlyout` with `MenuFlyout` for cases that need richer flyout behavior, shared popup content, or a flyout attached to a non-standard host.
 
 **❌ Incorrect**:
 ```xml

--- a/docs/proposals/xip/XIP0050-replace-fluentavaloniaui-with-official-avalonia-primitives.md
+++ b/docs/proposals/xip/XIP0050-replace-fluentavaloniaui-with-official-avalonia-primitives.md
@@ -8,6 +8,12 @@ This XIP is a concrete migration plan to remove the third-party `FluentAvaloniaU
 
 The goal is not to redesign the app. The goal is to find the closest official Avalonia replacements, preserve current behavior, and then delete the third-party package only after parity is proven.
 
+## Secondary Benefits
+
+1. Standard `ContextMenu` becomes viable again where a plain context menu is sufficient.
+2. The current lesson in [developers/lessons-learnt/general.md](../../../../developers/lessons-learnt/general.md) that says `ContextMenu` does not render correctly with `FluentAvaloniaTheme` should become obsolete after this migration is complete.
+3. `MenuFlyout` and `ContextFlyout` can then be reserved for cases that actually need flyout behavior, richer shared popup content, or button-attached flyouts rather than being required as a theme workaround.
+
 ## Why This XIP Exists
 
 Current local evidence shows that `XerahS.UI` depends on `FluentAvaloniaUI` in several places:
@@ -137,6 +143,16 @@ For each migrated area, record expected behavior before edits:
 6. what styles must remain recognizable
 
 This checklist becomes the acceptance contract for the migration.
+
+### A4. Record flyout and context-menu cleanup opportunities
+
+As part of the audit, identify where `MenuFlyout` or `ContextFlyout` is being used only because of the current `FluentAvaloniaTheme` limitation documented in [developers/lessons-learnt/general.md](../../../../developers/lessons-learnt/general.md).
+
+For each occurrence, classify it as one of:
+
+1. must remain a flyout because it is attached to a button or uses richer popup behavior
+2. can stay as a flyout because reuse/shared binding behavior is still useful
+3. can be simplified to a standard `ContextMenu` after migration to official Avalonia theme resources
 
 ## Workstream B: Prototype the shell and choose the replacement
 
@@ -311,6 +327,7 @@ The migration is complete only when all of the following are true:
 6. `AboutView` still presents grouped expandable sections with clickable rows
 7. workflow confirmation dialog still works
 8. `dotnet build` passes with `0` errors and warnings treated as errors
+9. the `ContextMenu vs. ContextFlyout` lesson in [developers/lessons-learnt/general.md](../../../../developers/lessons-learnt/general.md) is reviewed and either removed or rewritten once the migration proves that `ContextMenu` no longer requires a FluentAvalonia-specific workaround
 
 ## Verification Matrix
 
@@ -372,5 +389,11 @@ The migration is complete only when all of the following are true:
 9. Avalonia `Window` and `ShowDialog`
    - <https://api-docs.avaloniaui.net/docs/T_Avalonia_Controls_Window>
    - <https://api-docs.avaloniaui.net/docs/M_Avalonia_Controls_Window_ShowDialog__1>
-10. Avalonia controls namespace inventory
+10. Avalonia `ContextMenu`
+    - <https://docs.avaloniaui.net/docs/reference/controls/contextmenu>
+    - key finding: official Avalonia presents `ContextMenu` as a standard control and `ContextFlyout` as an alternative for richer or sharable UI, not as a mandatory workaround
+11. Avalonia `MenuFlyout`
+    - <https://docs.avaloniaui.net/docs/reference/controls/menu-flyout>
+    - key finding: official Avalonia documents `MenuFlyout` as an alternative to context menus, which supports treating current forced `MenuFlyout` usage as a FluentAvalonia-specific workaround rather than a permanent architectural requirement
+12. Avalonia controls namespace inventory
     - <https://api-docs.avaloniaui.net/docs/N_Avalonia_Controls>

--- a/src/desktop/app/XerahS.UI/App.axaml
+++ b/src/desktop/app/XerahS.UI/App.axaml
@@ -5,7 +5,6 @@
              xmlns:views="using:XerahS.UI.Views"
              xmlns:converters="clr-namespace:ShareX.ImageEditor.Presentation.Converters;assembly=ShareX.ImageEditor"
              xmlns:uiconverters="clr-namespace:XerahS.UI.Converters"
-             xmlns:sty="using:FluentAvalonia.Styling"
              xmlns:core="using:XerahS.Core"
              xmlns:common="clr-namespace:XerahS.Common;assembly=XerahS.Common"
              x:Class="XerahS.UI.App"
@@ -14,48 +13,54 @@
              <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
 
     <Application.Resources>
-        <converters:ActiveToolToBackgroundConverter x:Key="ActiveToolToBackground"/>
-        <converters:SelectedColorToBorderConverter x:Key="SelectedColorToBorder"/>
-        <converters:SelectedWidthToBackgroundConverter x:Key="SelectedWidthToBackground"/>
-        <converters:BoolToActiveBackgroundConverter x:Key="BoolToActiveBackgroundConverter"/>
-        <converters:EqualsConverter x:Key="EqualsConverter"/>
-        <uiconverters:BoolToRecordingColorConverter x:Key="BoolToRecordingColorConverter"/>
-        <uiconverters:ColorToNameConverter x:Key="ColorToNameConverter"/>
-        <!-- Shared context menu used by both History and Toast.
-             Hosts store IHistoryItemMenuContext in Tag so this single flyout can bind consistently. -->
-        <MenuFlyout x:Key="HistoryItemMenuFlyout"
-                    Opened="OnHistoryItemMenuFlyoutOpened">
-            <MenuItem Header="Edit..."
-                      Command="{Binding EditImageCommand}"
-                      InputGesture="Enter"/>
-            <MenuItem Header="Open File"
-                      Command="{Binding OpenFileCommand}"/>
-            <MenuItem Header="Upload"
-                      Command="{Binding UploadItemCommand}"/>
-            <MenuItem Header="Show in Explorer"
-                      Command="{Binding OpenFolderCommand}"/>
-            <Separator/>
-            <MenuItem Header="Copy Path"
-                      Command="{Binding CopyFilePathCommand}"/>
-            <MenuItem Header="Copy URL"
-                      Command="{Binding CopyURLCommand}"
-                      IsVisible="{Binding Item.URL, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
-            <MenuItem Header="Copy markdown image"
-                      Command="{Binding CopyMarkdownImageCommand}"
-                      IsVisible="{Binding Item.URL, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
-            <MenuItem Header="Copy image to clipboard"
-                      Command="{Binding CopyImageToClipboardCommand}"/>
-            <MenuItem Header="Copy Errors"
-                      Command="{Binding CopyErrorsCommand}"
-                      IsVisible="{Binding Item.HasErrors}"/>
-            <MenuItem Header="Open URL"
-                      Command="{Binding OpenURLCommand}"
-                      IsVisible="{Binding Item.URL, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
-            <Separator/>
-            <MenuItem Header="Delete"
-                      Command="{Binding DeleteItemCommand}"
-                      InputGesture="Delete"/>
-        </MenuFlyout>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceInclude Source="avares://ShareX.ImageEditor/Presentation/Theming/ShareXTheme.axaml" />
+            </ResourceDictionary.MergedDictionaries>
+
+            <converters:ActiveToolToBackgroundConverter x:Key="ActiveToolToBackground"/>
+            <converters:SelectedColorToBorderConverter x:Key="SelectedColorToBorder"/>
+            <converters:SelectedWidthToBackgroundConverter x:Key="SelectedWidthToBackground"/>
+            <converters:BoolToActiveBackgroundConverter x:Key="BoolToActiveBackgroundConverter"/>
+            <converters:EqualsConverter x:Key="EqualsConverter"/>
+            <uiconverters:BoolToRecordingColorConverter x:Key="BoolToRecordingColorConverter"/>
+            <uiconverters:ColorToNameConverter x:Key="ColorToNameConverter"/>
+            <!-- Shared context menu used by both History and Toast.
+                 Hosts store IHistoryItemMenuContext in Tag so this single flyout can bind consistently. -->
+            <MenuFlyout x:Key="HistoryItemMenuFlyout"
+                        Opened="OnHistoryItemMenuFlyoutOpened">
+                <MenuItem Header="Edit..."
+                          Command="{Binding EditImageCommand}"
+                          InputGesture="Enter"/>
+                <MenuItem Header="Open File"
+                          Command="{Binding OpenFileCommand}"/>
+                <MenuItem Header="Upload"
+                          Command="{Binding UploadItemCommand}"/>
+                <MenuItem Header="Show in Explorer"
+                          Command="{Binding OpenFolderCommand}"/>
+                <Separator/>
+                <MenuItem Header="Copy Path"
+                          Command="{Binding CopyFilePathCommand}"/>
+                <MenuItem Header="Copy URL"
+                          Command="{Binding CopyURLCommand}"
+                          IsVisible="{Binding Item.URL, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                <MenuItem Header="Copy markdown image"
+                          Command="{Binding CopyMarkdownImageCommand}"
+                          IsVisible="{Binding Item.URL, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                <MenuItem Header="Copy image to clipboard"
+                          Command="{Binding CopyImageToClipboardCommand}"/>
+                <MenuItem Header="Copy Errors"
+                          Command="{Binding CopyErrorsCommand}"
+                          IsVisible="{Binding Item.HasErrors}"/>
+                <MenuItem Header="Open URL"
+                          Command="{Binding OpenURLCommand}"
+                          IsVisible="{Binding Item.URL, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                <Separator/>
+                <MenuItem Header="Delete"
+                          Command="{Binding DeleteItemCommand}"
+                          InputGesture="Delete"/>
+            </MenuFlyout>
+        </ResourceDictionary>
     </Application.Resources>
 
 
@@ -80,9 +85,10 @@
     <Application.Styles>
         <!-- TODO: Re-enable dark theme when ready -->
         <!-- <StyleInclude Source="avares://ShareX.Avalonia.UI/Themes/Dark/DarkTheme.axaml" /> -->
-        <sty:FluentAvaloniaTheme />
+        <FluentTheme />
         <StyleInclude Source="avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml" />
         <StyleInclude Source="avares://XerahS.UI/Themes/Typography.axaml" />
+        <StyleInclude Source="avares://XerahS.UI/Themes/Compatibility.axaml" />
         <Style Selector="Button.DarkButton">
             <Setter Property="Background" Value="#25263A"/>
             <Setter Property="Foreground" Value="#E2E8F0"/>

--- a/src/desktop/app/XerahS.UI/Helpers/NavigationItemsHelper.cs
+++ b/src/desktop/app/XerahS.UI/Helpers/NavigationItemsHelper.cs
@@ -24,9 +24,9 @@
 #endregion License Information (GPL v3)
 
 using Avalonia;
-using FluentAvalonia.UI.Controls;
 using XerahS.Core;
 using XerahS.Core.Hotkeys;
+using XerahS.UI.ViewModels;
 
 namespace XerahS.UI.Helpers
 {
@@ -66,32 +66,20 @@ namespace XerahS.UI.Helpers
         }
 
         /// <summary>
-        /// Update navigation menu items for capture workflows.
-        /// This method is used by MainWindow to populate the Capture submenu.
+        /// Build navigation nodes for the first 3 capture workflows.
         /// </summary>
-        /// <param name="captureItem">The parent navigation item for capture</param>
-        public static void UpdateCaptureNavigationItems(NavigationViewItem captureItem)
+        public static IEnumerable<NavigationNode> CreateCaptureNavigationNodes()
         {
-            if (captureItem == null) return;
-
-            // Clear existing items
-            captureItem.MenuItems.Clear();
-
-            // Get first 3 workflows
             var workflows = GetTop3Workflows();
+            var navigationItems = new List<NavigationNode>(workflows.Count);
 
             for (int i = 0; i < workflows.Count; i++)
             {
                 var (id, displayName) = workflows[i];
-                var navItem = new NavigationViewItem
-                {
-                    Content = displayName,
-                    Tag = $"Capture_{id}", // Use ID-based tag instead of index
-                    SelectsOnInvoked = false  // Re-invocation always re-triggers the capture action (#170)
-                };
-
-                captureItem.MenuItems.Add(navItem);
+                navigationItems.Add(new NavigationNode(displayName, $"Capture_{id}", null, NavigationNodeKind.Action));
             }
+
+            return navigationItems;
         }
     }
 }

--- a/src/desktop/app/XerahS.UI/Themes/Compatibility.axaml
+++ b/src/desktop/app/XerahS.UI/Themes/Compatibility.axaml
@@ -1,0 +1,58 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <Styles.Resources>
+    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush"
+                     Color="{DynamicResource ShareX.Color.Background.Main}" />
+    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush"
+                     Color="{DynamicResource ShareX.Color.Background.Panel}" />
+    <SolidColorBrush x:Key="TextFillColorSecondaryBrush"
+                     Color="{DynamicResource ShareX.Color.Text.Secondary}" />
+    <SolidColorBrush x:Key="SurfaceStrokeColorDefaultBrush"
+                     Color="{DynamicResource ShareX.Color.Border}" />
+
+    <LinearGradientBrush x:Key="AccentFillColorDefaultBrush"
+                         StartPoint="0%,0%"
+                         EndPoint="100%,100%">
+      <GradientStop Color="{DynamicResource ShareX.Color.Accent.Start}" Offset="0" />
+      <GradientStop Color="{DynamicResource ShareX.Color.Accent.End}" Offset="1" />
+    </LinearGradientBrush>
+
+    <ControlTheme x:Key="CardBorderTheme" TargetType="Border">
+      <Setter Property="Background" Value="{DynamicResource SolidBackgroundFillColorSecondaryBrush}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource SurfaceStrokeColorDefaultBrush}" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="8" />
+    </ControlTheme>
+  </Styles.Resources>
+
+  <Style Selector="TextBlock.IconGlyph">
+    <Setter Property="FontFamily" Value="{DynamicResource ShareX.FontFamily.Icon}" />
+    <Setter Property="FontWeight" Value="Normal" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+  </Style>
+
+  <Style Selector="Separator.ToolbarSeparator">
+    <Setter Property="Width" Value="1" />
+    <Setter Property="MinHeight" Value="24" />
+    <Setter Property="Margin" Value="4,0" />
+    <Setter Property="Background" Value="{DynamicResource SurfaceStrokeColorDefaultBrush}" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+  </Style>
+
+  <Style Selector="Button.SettingsRow">
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="Padding" Value="14,12" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="CornerRadius" Value="8" />
+  </Style>
+
+  <Style Selector="Button.SettingsRow:pointerover">
+    <Setter Property="Background" Value="{DynamicResource SolidBackgroundFillColorSecondaryBrush}" />
+  </Style>
+
+  <Style Selector="Button.SettingsRow:pressed">
+    <Setter Property="Background" Value="{DynamicResource SolidBackgroundFillColorBaseBrush}" />
+  </Style>
+</Styles>

--- a/src/desktop/app/XerahS.UI/ViewModels/NavigationNode.cs
+++ b/src/desktop/app/XerahS.UI/ViewModels/NavigationNode.cs
@@ -1,0 +1,91 @@
+#region License Information (GPL v3)
+
+/*
+    XerahS - The Avalonia UI implementation of ShareX
+    Copyright (c) 2007-2026 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace XerahS.UI.ViewModels;
+
+public enum NavigationNodeKind
+{
+    Page,
+    Action,
+    Group
+}
+
+public partial class NavigationNode : ObservableObject
+{
+    public NavigationNode(string text, string? tag, string? glyph, NavigationNodeKind kind)
+    {
+        Text = text;
+        Tag = tag;
+        Glyph = glyph;
+        Kind = kind;
+    }
+
+    public string Text { get; }
+
+    public string? Tag { get; }
+
+    public string? Glyph { get; }
+
+    public NavigationNodeKind Kind { get; }
+
+    public ObservableCollection<NavigationNode> Children { get; } = new();
+
+    public NavigationNode? Parent { get; private set; }
+
+    public bool HasGlyph => !string.IsNullOrWhiteSpace(Glyph);
+
+    public void AddChild(NavigationNode child)
+    {
+        child.Parent = this;
+        Children.Add(child);
+    }
+
+    public void ReplaceChildren(IEnumerable<NavigationNode> children)
+    {
+        Children.Clear();
+
+        foreach (NavigationNode child in children)
+        {
+            AddChild(child);
+        }
+    }
+
+    public void ExpandPath()
+    {
+        for (NavigationNode? current = this; current != null; current = current.Parent)
+        {
+            if (current.Children.Count > 0)
+            {
+                current.IsExpanded = true;
+            }
+        }
+    }
+
+    [ObservableProperty]
+    private bool _isExpanded;
+}

--- a/src/desktop/app/XerahS.UI/Views/AboutView.axaml
+++ b/src/desktop/app/XerahS.UI/Views/AboutView.axaml
@@ -2,7 +2,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:common="using:XerahS.Common"
              xmlns:theming="clr-namespace:ShareX.ImageEditor.Presentation.Theming;assembly=ShareX.ImageEditor"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
@@ -10,220 +9,200 @@
 
     <ScrollViewer Padding="24">
         <StackPanel Spacing="24" MaxWidth="800" HorizontalAlignment="Center">
-            
-            <!-- Header -->
             <StackPanel Spacing="16" HorizontalAlignment="Center" Margin="0,32,0,32">
                 <Image Source="/Assets/Logo.png" Height="128" Width="128" />
-                <TextBlock Text="{x:Static common:AppResources.ProductNameWithVersion}" 
-                           Theme="{StaticResource TitleTextBlockStyle}" 
+                <TextBlock Text="{x:Static common:AppResources.ProductNameWithVersion}"
+                           Theme="{StaticResource TitleTextBlockStyle}"
                            HorizontalAlignment="Center" />
-                 <TextBlock Text="Copyright (c) 2007-2026 ShareX Team" 
-                            Theme="{StaticResource CaptionTextBlockStyle}" 
-                            HorizontalAlignment="Center" Opacity="0.6"/>
+                <TextBlock Text="Copyright (c) 2007-2026 ShareX Team"
+                           Theme="{StaticResource CaptionTextBlockStyle}"
+                           HorizontalAlignment="Center"
+                           Opacity="0.6" />
             </StackPanel>
 
-            <ui:SettingsExpander Header="Links" IsExpanded="True">
-                 <ui:SettingsExpander.IconSource>
-                     <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                        FontSize="16"
-                                        FontWeight="Normal"
-                                        Glyph="{x:Static theming:HostIcons.SectionLinks}"/>
-                 </ui:SettingsExpander.IconSource>
-                 <ui:SettingsExpander.Items>
-                     <ui:SettingsExpanderItem HorizontalContentAlignment="Stretch" MinWidth="720" IsClickEnabled="True" Cursor="Hand" Click="OnLinkClick" Tag="{x:Static common:Links.XerahSWebsite}">
-                         <ui:SettingsExpanderItem.Content>
-                             <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16" Margin="0,0,8,0">
-                                 <TextBlock Text="Website" VerticalAlignment="Center" />
-                                 <TextBlock Grid.Column="1"
-                                            Text="{Binding Tag, RelativeSource={RelativeSource AncestorType=ui:SettingsExpanderItem}}"
-                                            VerticalAlignment="Center"
-                                            TextAlignment="Right"
-                                            Opacity="0.75" />
-                             </Grid>
-                         </ui:SettingsExpanderItem.Content>
-                         <ui:SettingsExpanderItem.ActionIconSource>
-                             <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                                FontSize="14"
-                                                FontWeight="Normal"
-                                                Glyph="{x:Static theming:HostIcons.ActionOpenLink}"/>
-                         </ui:SettingsExpanderItem.ActionIconSource>
-                     </ui:SettingsExpanderItem>
-                     <ui:SettingsExpanderItem HorizontalContentAlignment="Stretch" MinWidth="720" IsClickEnabled="True" Cursor="Hand" Click="OnLinkClick" Tag="{x:Static common:Links.GitHub}">
-                         <ui:SettingsExpanderItem.Content>
-                             <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16" Margin="0,0,8,0">
-                                 <TextBlock Text="GitHub Project" VerticalAlignment="Center" />
-                                 <TextBlock Grid.Column="1"
-                                            Text="{Binding Tag, RelativeSource={RelativeSource AncestorType=ui:SettingsExpanderItem}}"
-                                            VerticalAlignment="Center"
-                                            TextAlignment="Right"
-                                            Opacity="0.75" />
-                             </Grid>
-                         </ui:SettingsExpanderItem.Content>
-                         <ui:SettingsExpanderItem.ActionIconSource>
-                             <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                                FontSize="14"
-                                                FontWeight="Normal"
-                                                Glyph="{x:Static theming:HostIcons.ActionOpenLink}"/>
-                         </ui:SettingsExpanderItem.ActionIconSource>
-                     </ui:SettingsExpanderItem>
-                     <ui:SettingsExpanderItem HorizontalContentAlignment="Stretch" MinWidth="720" IsClickEnabled="True" Cursor="Hand" Click="OnLinkClick" Tag="https://github.com/ShareX/XerahS/issues/">
-                         <ui:SettingsExpanderItem.Content>
-                             <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16" Margin="0,0,8,0">
-                                 <TextBlock Text="Issues" VerticalAlignment="Center" />
-                                 <TextBlock Grid.Column="1"
-                                            Text="{Binding Tag, RelativeSource={RelativeSource AncestorType=ui:SettingsExpanderItem}}"
-                                            VerticalAlignment="Center"
-                                            TextAlignment="Right"
-                                            Opacity="0.75" />
-                             </Grid>
-                         </ui:SettingsExpanderItem.Content>
-                         <ui:SettingsExpanderItem.ActionIconSource>
-                             <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                                FontSize="14"
-                                                FontWeight="Normal"
-                                                Glyph="{x:Static theming:HostIcons.ActionOpenLink}"/>
-                         </ui:SettingsExpanderItem.ActionIconSource>
-                     </ui:SettingsExpanderItem>
-                     <ui:SettingsExpanderItem HorizontalContentAlignment="Stretch" MinWidth="720" IsClickEnabled="True" Cursor="Hand" Click="OnLinkClick" Tag="{x:Static common:Links.Contributors}">
-                         <ui:SettingsExpanderItem.Content>
-                             <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16" Margin="0,0,8,0">
-                                 <TextBlock Text="Contributors" VerticalAlignment="Center" />
-                                 <TextBlock Grid.Column="1"
-                                            Text="{Binding Tag, RelativeSource={RelativeSource AncestorType=ui:SettingsExpanderItem}}"
-                                            VerticalAlignment="Center"
-                                            TextAlignment="Right"
-                                            Opacity="0.75" />
-                             </Grid>
-                         </ui:SettingsExpanderItem.Content>
-                         <ui:SettingsExpanderItem.ActionIconSource>
-                             <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                                FontSize="14"
-                                                FontWeight="Normal"
-                                                Glyph="{x:Static theming:HostIcons.ActionOpenLink}"/>
-                         </ui:SettingsExpanderItem.ActionIconSource>
-                     </ui:SettingsExpanderItem>
-                     <ui:SettingsExpanderItem HorizontalContentAlignment="Stretch" MinWidth="720" IsClickEnabled="True" Cursor="Hand" Click="OnLinkClick" Tag="{x:Static common:Links.Changelog}">
-                         <ui:SettingsExpanderItem.Content>
-                             <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16" Margin="0,0,8,0">
-                                 <TextBlock Text="Changelog" VerticalAlignment="Center" />
-                                 <TextBlock Grid.Column="1"
-                                            Text="{Binding Tag, RelativeSource={RelativeSource AncestorType=ui:SettingsExpanderItem}}"
-                                            VerticalAlignment="Center"
-                                            TextAlignment="Right"
-                                            Opacity="0.75" />
-                             </Grid>
-                         </ui:SettingsExpanderItem.Content>
-                         <ui:SettingsExpanderItem.ActionIconSource>
-                             <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                                FontSize="14"
-                                                FontWeight="Normal"
-                                                Glyph="{x:Static theming:HostIcons.ActionOpenLink}"/>
-                         </ui:SettingsExpanderItem.ActionIconSource>
-                     </ui:SettingsExpanderItem>
-                     <ui:SettingsExpanderItem HorizontalContentAlignment="Stretch" MinWidth="720" IsClickEnabled="True" Cursor="Hand" Click="OnLinkClick" Tag="{x:Static common:Links.PrivacyPolicy}">
-                         <ui:SettingsExpanderItem.Content>
-                             <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16" Margin="0,0,8,0">
-                                 <TextBlock Text="Privacy Policy" VerticalAlignment="Center" />
-                                 <TextBlock Grid.Column="1"
-                                            Text="{Binding Tag, RelativeSource={RelativeSource AncestorType=ui:SettingsExpanderItem}}"
-                                            VerticalAlignment="Center"
-                                            TextAlignment="Right"
-                                            Opacity="0.75" />
-                             </Grid>
-                         </ui:SettingsExpanderItem.Content>
-                         <ui:SettingsExpanderItem.ActionIconSource>
-                             <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                                FontSize="14"
-                                                FontWeight="Normal"
-                                                Glyph="{x:Static theming:HostIcons.ActionOpenLink}"/>
-                         </ui:SettingsExpanderItem.ActionIconSource>
-                     </ui:SettingsExpanderItem>
-                     <ui:SettingsExpanderItem HorizontalContentAlignment="Stretch" MinWidth="720" IsClickEnabled="True" Cursor="Hand" Click="OnLinkClick" Tag="{x:Static common:Links.Donate}">
-                         <ui:SettingsExpanderItem.Content>
-                             <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16" Margin="0,0,8,0">
-                                 <TextBlock Text="Donate" VerticalAlignment="Center" />
-                                 <TextBlock Grid.Column="1"
-                                            Text="{Binding Tag, RelativeSource={RelativeSource AncestorType=ui:SettingsExpanderItem}}"
-                                            VerticalAlignment="Center"
-                                            TextAlignment="Right"
-                                            Opacity="0.75" />
-                             </Grid>
-                         </ui:SettingsExpanderItem.Content>
-                         <ui:SettingsExpanderItem.ActionIconSource>
-                             <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                                FontSize="14"
-                                                FontWeight="Normal"
-                                                Glyph="{x:Static theming:HostIcons.ActionOpenLink}"/>
-                         </ui:SettingsExpanderItem.ActionIconSource>
-                     </ui:SettingsExpanderItem>
-                 </ui:SettingsExpander.Items>
-            </ui:SettingsExpander>
+            <Border Theme="{StaticResource CardBorderTheme}" Padding="16">
+                <Expander Header="Links" IsExpanded="True">
+                    <Expander.Header>
+                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="12">
+                            <TextBlock Classes="IconGlyph"
+                                       FontSize="16"
+                                       Text="{x:Static theming:HostIcons.SectionLinks}" />
+                            <TextBlock Grid.Column="1"
+                                       Text="Links"
+                                       VerticalAlignment="Center" />
+                        </Grid>
+                    </Expander.Header>
 
-            <ui:SettingsExpander Header="Social" IsExpanded="True">
-                 <ui:SettingsExpander.IconSource>
-                     <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                        FontSize="16"
-                                        FontWeight="Normal"
-                                        Glyph="{x:Static theming:HostIcons.SectionSocial}"/>
-                 </ui:SettingsExpander.IconSource>
-                 <ui:SettingsExpander.Items>
-                     <ui:SettingsExpanderItem HorizontalContentAlignment="Stretch" MinWidth="720" IsClickEnabled="True" Cursor="Hand" Click="OnLinkClick" Tag="{x:Static common:Links.X}">
-                         <ui:SettingsExpanderItem.Content>
-                             <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16" Margin="0,0,8,0">
-                                 <TextBlock Text="X" VerticalAlignment="Center" />
-                                 <TextBlock Grid.Column="1"
-                                            Text="{Binding Tag, RelativeSource={RelativeSource AncestorType=ui:SettingsExpanderItem}}"
-                                            VerticalAlignment="Center"
-                                            TextAlignment="Right"
-                                            Opacity="0.75" />
-                             </Grid>
-                         </ui:SettingsExpanderItem.Content>
-                         <ui:SettingsExpanderItem.ActionIconSource>
-                             <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                                FontSize="14"
-                                                FontWeight="Normal"
-                                                Glyph="{x:Static theming:HostIcons.ActionOpenLink}"/>
-                         </ui:SettingsExpanderItem.ActionIconSource>
-                     </ui:SettingsExpanderItem>
-                     <ui:SettingsExpanderItem HorizontalContentAlignment="Stretch" MinWidth="720" IsClickEnabled="True" Cursor="Hand" Click="OnLinkClick" Tag="{x:Static common:Links.Discord}">
-                         <ui:SettingsExpanderItem.Content>
-                             <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16" Margin="0,0,8,0">
-                                 <TextBlock Text="Discord" VerticalAlignment="Center" />
-                                 <TextBlock Grid.Column="1"
-                                            Text="{Binding Tag, RelativeSource={RelativeSource AncestorType=ui:SettingsExpanderItem}}"
-                                            VerticalAlignment="Center"
-                                            TextAlignment="Right"
-                                            Opacity="0.75" />
-                             </Grid>
-                         </ui:SettingsExpanderItem.Content>
-                         <ui:SettingsExpanderItem.ActionIconSource>
-                             <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                                FontSize="14"
-                                                FontWeight="Normal"
-                                                Glyph="{x:Static theming:HostIcons.ActionOpenLink}"/>
-                         </ui:SettingsExpanderItem.ActionIconSource>
-                     </ui:SettingsExpanderItem>
-                     <ui:SettingsExpanderItem HorizontalContentAlignment="Stretch" MinWidth="720" IsClickEnabled="True" Cursor="Hand" Click="OnLinkClick" Tag="{x:Static common:Links.Reddit}">
-                         <ui:SettingsExpanderItem.Content>
-                             <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16" Margin="0,0,8,0">
-                                 <TextBlock Text="Reddit" VerticalAlignment="Center" />
-                                 <TextBlock Grid.Column="1"
-                                            Text="{Binding Tag, RelativeSource={RelativeSource AncestorType=ui:SettingsExpanderItem}}"
-                                            VerticalAlignment="Center"
-                                            TextAlignment="Right"
-                                            Opacity="0.75" />
-                             </Grid>
-                         </ui:SettingsExpanderItem.Content>
-                         <ui:SettingsExpanderItem.ActionIconSource>
-                             <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                                FontSize="14"
-                                                FontWeight="Normal"
-                                                Glyph="{x:Static theming:HostIcons.ActionOpenLink}"/>
-                         </ui:SettingsExpanderItem.ActionIconSource>
-                     </ui:SettingsExpanderItem>
-                 </ui:SettingsExpander.Items>
-            </ui:SettingsExpander>
+                    <StackPanel Margin="0,16,0,0" Spacing="8">
+                        <Button Classes="SettingsRow" Click="OnLinkClick" Tag="{x:Static common:Links.XerahSWebsite}">
+                            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="16">
+                                <TextBlock Text="Website" VerticalAlignment="Center" />
+                                <TextBlock Grid.Column="1"
+                                           Text="{Binding Tag, RelativeSource={RelativeSource AncestorType=Button}}"
+                                           VerticalAlignment="Center"
+                                           TextAlignment="Right"
+                                           Opacity="0.75" />
+                                <TextBlock Grid.Column="2"
+                                           Classes="IconGlyph"
+                                           FontSize="14"
+                                           Text="{x:Static theming:HostIcons.ActionOpenLink}" />
+                            </Grid>
+                        </Button>
 
+                        <Button Classes="SettingsRow" Click="OnLinkClick" Tag="{x:Static common:Links.GitHub}">
+                            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="16">
+                                <TextBlock Text="GitHub Project" VerticalAlignment="Center" />
+                                <TextBlock Grid.Column="1"
+                                           Text="{Binding Tag, RelativeSource={RelativeSource AncestorType=Button}}"
+                                           VerticalAlignment="Center"
+                                           TextAlignment="Right"
+                                           Opacity="0.75" />
+                                <TextBlock Grid.Column="2"
+                                           Classes="IconGlyph"
+                                           FontSize="14"
+                                           Text="{x:Static theming:HostIcons.ActionOpenLink}" />
+                            </Grid>
+                        </Button>
+
+                        <Button Classes="SettingsRow" Click="OnLinkClick" Tag="https://github.com/ShareX/XerahS/issues/">
+                            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="16">
+                                <TextBlock Text="Issues" VerticalAlignment="Center" />
+                                <TextBlock Grid.Column="1"
+                                           Text="{Binding Tag, RelativeSource={RelativeSource AncestorType=Button}}"
+                                           VerticalAlignment="Center"
+                                           TextAlignment="Right"
+                                           Opacity="0.75" />
+                                <TextBlock Grid.Column="2"
+                                           Classes="IconGlyph"
+                                           FontSize="14"
+                                           Text="{x:Static theming:HostIcons.ActionOpenLink}" />
+                            </Grid>
+                        </Button>
+
+                        <Button Classes="SettingsRow" Click="OnLinkClick" Tag="{x:Static common:Links.Contributors}">
+                            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="16">
+                                <TextBlock Text="Contributors" VerticalAlignment="Center" />
+                                <TextBlock Grid.Column="1"
+                                           Text="{Binding Tag, RelativeSource={RelativeSource AncestorType=Button}}"
+                                           VerticalAlignment="Center"
+                                           TextAlignment="Right"
+                                           Opacity="0.75" />
+                                <TextBlock Grid.Column="2"
+                                           Classes="IconGlyph"
+                                           FontSize="14"
+                                           Text="{x:Static theming:HostIcons.ActionOpenLink}" />
+                            </Grid>
+                        </Button>
+
+                        <Button Classes="SettingsRow" Click="OnLinkClick" Tag="{x:Static common:Links.Changelog}">
+                            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="16">
+                                <TextBlock Text="Changelog" VerticalAlignment="Center" />
+                                <TextBlock Grid.Column="1"
+                                           Text="{Binding Tag, RelativeSource={RelativeSource AncestorType=Button}}"
+                                           VerticalAlignment="Center"
+                                           TextAlignment="Right"
+                                           Opacity="0.75" />
+                                <TextBlock Grid.Column="2"
+                                           Classes="IconGlyph"
+                                           FontSize="14"
+                                           Text="{x:Static theming:HostIcons.ActionOpenLink}" />
+                            </Grid>
+                        </Button>
+
+                        <Button Classes="SettingsRow" Click="OnLinkClick" Tag="{x:Static common:Links.PrivacyPolicy}">
+                            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="16">
+                                <TextBlock Text="Privacy Policy" VerticalAlignment="Center" />
+                                <TextBlock Grid.Column="1"
+                                           Text="{Binding Tag, RelativeSource={RelativeSource AncestorType=Button}}"
+                                           VerticalAlignment="Center"
+                                           TextAlignment="Right"
+                                           Opacity="0.75" />
+                                <TextBlock Grid.Column="2"
+                                           Classes="IconGlyph"
+                                           FontSize="14"
+                                           Text="{x:Static theming:HostIcons.ActionOpenLink}" />
+                            </Grid>
+                        </Button>
+
+                        <Button Classes="SettingsRow" Click="OnLinkClick" Tag="{x:Static common:Links.Donate}">
+                            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="16">
+                                <TextBlock Text="Donate" VerticalAlignment="Center" />
+                                <TextBlock Grid.Column="1"
+                                           Text="{Binding Tag, RelativeSource={RelativeSource AncestorType=Button}}"
+                                           VerticalAlignment="Center"
+                                           TextAlignment="Right"
+                                           Opacity="0.75" />
+                                <TextBlock Grid.Column="2"
+                                           Classes="IconGlyph"
+                                           FontSize="14"
+                                           Text="{x:Static theming:HostIcons.ActionOpenLink}" />
+                            </Grid>
+                        </Button>
+                    </StackPanel>
+                </Expander>
+            </Border>
+
+            <Border Theme="{StaticResource CardBorderTheme}" Padding="16">
+                <Expander Header="Social" IsExpanded="True">
+                    <Expander.Header>
+                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="12">
+                            <TextBlock Classes="IconGlyph"
+                                       FontSize="16"
+                                       Text="{x:Static theming:HostIcons.SectionSocial}" />
+                            <TextBlock Grid.Column="1"
+                                       Text="Social"
+                                       VerticalAlignment="Center" />
+                        </Grid>
+                    </Expander.Header>
+
+                    <StackPanel Margin="0,16,0,0" Spacing="8">
+                        <Button Classes="SettingsRow" Click="OnLinkClick" Tag="{x:Static common:Links.X}">
+                            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="16">
+                                <TextBlock Text="X" VerticalAlignment="Center" />
+                                <TextBlock Grid.Column="1"
+                                           Text="{Binding Tag, RelativeSource={RelativeSource AncestorType=Button}}"
+                                           VerticalAlignment="Center"
+                                           TextAlignment="Right"
+                                           Opacity="0.75" />
+                                <TextBlock Grid.Column="2"
+                                           Classes="IconGlyph"
+                                           FontSize="14"
+                                           Text="{x:Static theming:HostIcons.ActionOpenLink}" />
+                            </Grid>
+                        </Button>
+
+                        <Button Classes="SettingsRow" Click="OnLinkClick" Tag="{x:Static common:Links.Discord}">
+                            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="16">
+                                <TextBlock Text="Discord" VerticalAlignment="Center" />
+                                <TextBlock Grid.Column="1"
+                                           Text="{Binding Tag, RelativeSource={RelativeSource AncestorType=Button}}"
+                                           VerticalAlignment="Center"
+                                           TextAlignment="Right"
+                                           Opacity="0.75" />
+                                <TextBlock Grid.Column="2"
+                                           Classes="IconGlyph"
+                                           FontSize="14"
+                                           Text="{x:Static theming:HostIcons.ActionOpenLink}" />
+                            </Grid>
+                        </Button>
+
+                        <Button Classes="SettingsRow" Click="OnLinkClick" Tag="{x:Static common:Links.Reddit}">
+                            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="16">
+                                <TextBlock Text="Reddit" VerticalAlignment="Center" />
+                                <TextBlock Grid.Column="1"
+                                           Text="{Binding Tag, RelativeSource={RelativeSource AncestorType=Button}}"
+                                           VerticalAlignment="Center"
+                                           TextAlignment="Right"
+                                           Opacity="0.75" />
+                                <TextBlock Grid.Column="2"
+                                           Classes="IconGlyph"
+                                           FontSize="14"
+                                           Text="{x:Static theming:HostIcons.ActionOpenLink}" />
+                            </Grid>
+                        </Button>
+                    </StackPanel>
+                </Expander>
+            </Border>
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/src/desktop/app/XerahS.UI/Views/AboutView.axaml.cs
+++ b/src/desktop/app/XerahS.UI/Views/AboutView.axaml.cs
@@ -20,7 +20,6 @@
 
 using Avalonia.Controls;
 using Avalonia.Interactivity;
-using FluentAvalonia.UI.Controls;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using XerahS.Common;
@@ -36,7 +35,7 @@ namespace XerahS.UI.Views
 
         private void OnLinkClick(object sender, RoutedEventArgs e)
         {
-            if (sender is SettingsExpanderItem item && item.Tag is string url)
+            if (sender is Control { Tag: string url })
             {
                 OpenUrl(url);
             }

--- a/src/desktop/app/XerahS.UI/Views/Dialogs/ConfirmationDialog.axaml
+++ b/src/desktop/app/XerahS.UI/Views/Dialogs/ConfirmationDialog.axaml
@@ -1,0 +1,31 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="XerahS.UI.Views.Dialogs.ConfirmationDialog"
+        Width="420"
+        SizeToContent="Height"
+        MinWidth="420"
+        CanResize="False"
+        ShowInTaskbar="False"
+        WindowStartupLocation="CenterOwner">
+    <Border Background="{DynamicResource SolidBackgroundFillColorSecondaryBrush}"
+            BorderBrush="{DynamicResource SurfaceStrokeColorDefaultBrush}"
+            BorderThickness="1"
+            Padding="16">
+        <StackPanel Spacing="12">
+            <TextBlock x:Name="DialogTitleText"
+                       FontSize="16"
+                       FontWeight="SemiBold" />
+            <TextBlock x:Name="DialogMessageText"
+                       TextWrapping="Wrap" />
+            <StackPanel Orientation="Horizontal"
+                        HorizontalAlignment="Right"
+                        Spacing="8">
+                <Button x:Name="CancelButton"
+                        Click="OnCancelClick" />
+                <Button x:Name="ConfirmButton"
+                        Classes="accent"
+                        Click="OnConfirmClick" />
+            </StackPanel>
+        </StackPanel>
+    </Border>
+</Window>

--- a/src/desktop/app/XerahS.UI/Views/Dialogs/ConfirmationDialog.axaml.cs
+++ b/src/desktop/app/XerahS.UI/Views/Dialogs/ConfirmationDialog.axaml.cs
@@ -1,0 +1,59 @@
+#region License Information (GPL v3)
+
+/*
+    XerahS - The Avalonia UI implementation of ShareX
+    Copyright (c) 2007-2026 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+
+namespace XerahS.UI.Views.Dialogs;
+
+public partial class ConfirmationDialog : Window
+{
+    public ConfirmationDialog()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public ConfirmationDialog(string title, string message, string confirmText = "Yes", string cancelText = "No")
+        : this()
+    {
+
+        Title = title;
+        this.FindControl<TextBlock>("DialogTitleText")!.Text = title;
+        this.FindControl<TextBlock>("DialogMessageText")!.Text = message;
+        this.FindControl<Button>("ConfirmButton")!.Content = confirmText;
+        this.FindControl<Button>("CancelButton")!.Content = cancelText;
+    }
+
+    private void OnConfirmClick(object? sender, RoutedEventArgs e)
+    {
+        Close(true);
+    }
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e)
+    {
+        Close(false);
+    }
+}

--- a/src/desktop/app/XerahS.UI/Views/MainWindow.Navigation.cs
+++ b/src/desktop/app/XerahS.UI/Views/MainWindow.Navigation.cs
@@ -25,21 +25,25 @@
 
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using System;
 using System.Collections;
 using System.Linq;
-using FluentAvalonia.UI.Controls;
+using ShareX.ImageEditor.Presentation.Theming;
 using ShareX.ImageEditor.Presentation.Views;
 using XerahS.Core;
 using XerahS.Core.Hotkeys;
 using XerahS.Core.Managers;
 using XerahS.UI.Helpers;
+using XerahS.UI.ViewModels;
 
 namespace XerahS.UI.Views
 {
     public partial class MainWindow
     {
+        private NavigationNode? _captureNavigationNode;
+
         private void OnMenuNavigateClick(object? sender, RoutedEventArgs e)
         {
             if (sender is not MenuItem menuItem)
@@ -47,7 +51,7 @@ namespace XerahS.UI.Views
                 return;
             }
 
-            var navTag = menuItem.Tag?.ToString();
+            string? navTag = menuItem.Tag?.ToString();
             if (string.IsNullOrWhiteSpace(navTag))
             {
                 return;
@@ -56,67 +60,48 @@ namespace XerahS.UI.Views
             NavigateTo(navTag);
         }
 
-        private void OnNavSelectionChanged(object? sender, NavigationViewSelectionChangedEventArgs e)
+        private void OnNavSelectionChanged(object? sender, SelectionChangedEventArgs e)
         {
-            var navView = sender as NavigationView;
-            var contentFrame = this.FindControl<ContentControl>("ContentFrame");
-            var selectedItem = navView?.SelectedItem as NavigationViewItem;
+            ContentControl? contentFrame = this.FindControl<ContentControl>("ContentFrame");
+            NavigationNode? selectedItem = (sender as TreeView)?.SelectedItem as NavigationNode;
 
-            if (contentFrame == null || selectedItem == null)
+            if (contentFrame == null || selectedItem == null || selectedItem.Kind != NavigationNodeKind.Page)
             {
                 return;
             }
 
-            // Skip items handled by OnNavItemInvoked (action items with SelectsOnInvoked=False
-            // may still raise SelectionChanged in some FluentAvalonia builds — guard here).
-            var tag = selectedItem.Tag?.ToString();
-            if (IsActionOnlyNavTag(tag))
-            {
-                return;
-            }
-
-            HandleNavigationTag(tag, contentFrame);
+            HandleNavigationTag(selectedItem.Tag, contentFrame);
         }
 
-        /// <summary>
-        /// Fires on every click/tap of a nav item, even when the item is already selected.
-        /// Used for action-only items (Upload, Capture workflows) so that re-clicking them
-        /// always re-triggers their associated action (fixes issue #170).
-        /// </summary>
-        private void OnNavItemInvoked(object? sender, NavigationViewItemInvokedEventArgs e)
+        private void OnNavigationNodeTapped(object? sender, TappedEventArgs e)
         {
-            var invokedItem = e.InvokedItemContainer as NavigationViewItem;
-            var tag = invokedItem?.Tag?.ToString();
-
-            if (!IsActionOnlyNavTag(tag))
+            if (sender is not Control control || control.DataContext is not NavigationNode node)
             {
                 return;
             }
 
-            var contentFrame = this.FindControl<ContentControl>("ContentFrame");
-            if (contentFrame != null)
+            if (InvokeNavigationNode(node, toggleGroups: true))
             {
-                HandleNavigationTag(tag, contentFrame);
+                e.Handled = true;
             }
         }
 
-        /// <summary>
-        /// Returns true for nav tags that map to immediate actions (dialogs, tool windows, workflows)
-        /// rather than page navigation. These items use ItemInvoked instead of SelectionChanged.
-        /// </summary>
-        private static bool IsActionOnlyNavTag(string? tag)
+        private void OnNavigationTreeKeyDown(object? sender, KeyEventArgs e)
         {
-            if (string.IsNullOrEmpty(tag))
+            if (e.Key != Key.Enter && e.Key != Key.Space)
             {
-                return false;
+                return;
             }
 
-            // "Tools" (no underscore) navigates to ToolsView page; "Tools_*" sub-items open dialogs/windows.
-            return tag.StartsWith("Capture_", StringComparison.Ordinal)
-                || tag.StartsWith("Workflow_", StringComparison.Ordinal)
-                || tag.StartsWith("Tools_", StringComparison.Ordinal)
-                || tag == "Upload_FileUpload"
-                || tag == "Upload_ClipboardUploadWithContentViewer";
+            if ((sender as TreeView)?.SelectedItem is not NavigationNode node)
+            {
+                return;
+            }
+
+            if (InvokeNavigationNode(node, toggleGroups: true))
+            {
+                e.Handled = true;
+            }
         }
 
         private bool HandleNavigationTag(string? tag, ContentControl contentFrame)
@@ -126,21 +111,18 @@ namespace XerahS.UI.Views
                 return false;
             }
 
-            // Handle workflow execution by ID
             if (tag.StartsWith("Capture_", StringComparison.Ordinal))
             {
-                var workflowId = tag.Replace("Capture_", "", StringComparison.Ordinal);
+                string workflowId = tag.Replace("Capture_", "", StringComparison.Ordinal);
                 if (!string.IsNullOrEmpty(workflowId))
                 {
                     WorkflowSettings? workflow = null;
 
-                    // Try to get workflow from WorkflowManager first
                     if (Application.Current is App app && app.WorkflowManager != null)
                     {
                         workflow = app.WorkflowManager.GetWorkflowById(workflowId);
                     }
 
-                    // Fallback to SettingManager
                     if (workflow == null)
                     {
                         workflow = SettingsManager.WorkflowsConfig.Hotkeys.FirstOrDefault(w => w.Id == workflowId);
@@ -157,13 +139,12 @@ namespace XerahS.UI.Views
                 return false;
             }
 
-            // Handle workflow execution by ID from menu
             if (tag.StartsWith("Workflow_", StringComparison.Ordinal))
             {
-                var workflowId = tag.Replace("Workflow_", "", StringComparison.Ordinal);
+                string workflowId = tag.Replace("Workflow_", "", StringComparison.Ordinal);
                 if (!string.IsNullOrEmpty(workflowId))
                 {
-                    var workflow = SettingsManager.WorkflowsConfig?.Hotkeys?.FirstOrDefault(w => w.Id == workflowId);
+                    WorkflowSettings? workflow = SettingsManager.WorkflowsConfig?.Hotkeys?.FirstOrDefault(w => w.Id == workflowId);
                     if (workflow != null)
                     {
                         _ = ExecuteCaptureAsync(workflow.Job, workflow.Id);
@@ -220,6 +201,25 @@ namespace XerahS.UI.Views
             }
         }
 
+        private void BuildNavigationNodes()
+        {
+            NavigationNodes.Clear();
+
+            _captureNavigationNode = CreateNode("Capture", "Capture", HostIcons.NavigationCapture, NavigationNodeKind.Group, isExpanded: true);
+            NavigationNodes.Add(_captureNavigationNode);
+            NavigationNodes.Add(CreateNode("Recording", "Recording", HostIcons.NavigationRecording, NavigationNodeKind.Page));
+            NavigationNodes.Add(CreateNode("Editor", "Editor", HostIcons.NavigationEditor, NavigationNodeKind.Page));
+            NavigationNodes.Add(CreateNode("History", "History", HostIcons.NavigationHistory, NavigationNodeKind.Page));
+            NavigationNodes.Add(CreateNode("Workflows", "Workflows", HostIcons.NavigationWorkflows, NavigationNodeKind.Page));
+            NavigationNodes.Add(CreateUploadNode());
+            NavigationNodes.Add(CreateToolsNode());
+            NavigationNodes.Add(CreateSettingsNode());
+            NavigationNodes.Add(CreateNode("Debug", "Debug", HostIcons.NavigationDebug, NavigationNodeKind.Page));
+            NavigationNodes.Add(CreateNode("About", "About", HostIcons.NavigationAbout, NavigationNodeKind.Page));
+
+            UpdateNavigationItems();
+        }
+
         public void NavigateToEditor()
         {
             NavigateTo("Editor");
@@ -243,40 +243,40 @@ namespace XerahS.UI.Views
         private void NavigateTo(string navTag)
         {
             bool handled = false;
-            var contentFrame = this.FindControl<ContentControl>("ContentFrame");
-            var navView = this.FindControl<NavigationView>("NavView");
-            if (navView != null)
+            ContentControl? contentFrame = this.FindControl<ContentControl>("ContentFrame");
+            TreeView? navigationTree = this.FindControl<TreeView>("NavigationTree");
+
+            if (navigationTree != null)
             {
-                var navItem = FindNavigationItemByTag(navView.MenuItems, navTag);
-                if (navItem != null)
+                NavigationNode? navNode = FindNavigationNodeByTag(NavigationNodes, navTag);
+                if (navNode != null)
                 {
-                    if (IsActionOnlyNavTag(navTag))
+                    navNode.ExpandPath();
+
+                    if (navNode.Kind == NavigationNodeKind.Action)
                     {
-                        // Action-only items must not change nav selection — execute directly.
                         if (contentFrame != null)
                         {
                             handled = HandleNavigationTag(navTag, contentFrame);
                         }
                     }
-                    else if (!ReferenceEquals(navView.SelectedItem, navItem))
+                    else if (navNode.Kind == NavigationNodeKind.Page && !ReferenceEquals(navigationTree.SelectedItem, navNode))
                     {
-                        navView.SelectedItem = navItem;
+                        navigationTree.SelectedItem = navNode;
                         handled = true;
                     }
-                    else if (contentFrame != null)
+                    else if (navNode.Kind == NavigationNodeKind.Page && contentFrame != null)
                     {
                         handled = HandleNavigationTag(navTag, contentFrame);
                     }
                 }
             }
 
-            // Menu-bar actions may not have a corresponding NavigationView item.
             if (!handled && contentFrame != null)
             {
                 _ = HandleNavigationTag(navTag, contentFrame);
             }
 
-            // Ensure window is visible and active
             if (!this.IsVisible)
             {
                 this.Show();
@@ -291,26 +291,63 @@ namespace XerahS.UI.Views
             this.Focus();
         }
 
-        private static NavigationViewItem? FindNavigationItemByTag(IEnumerable? menuItems, string navTag)
+        private bool InvokeNavigationNode(NavigationNode node, bool toggleGroups)
+        {
+            TreeView? navigationTree = this.FindControl<TreeView>("NavigationTree");
+            ContentControl? contentFrame = this.FindControl<ContentControl>("ContentFrame");
+
+            if (node.Kind == NavigationNodeKind.Group)
+            {
+                if (toggleGroups)
+                {
+                    node.IsExpanded = !node.IsExpanded;
+                    return true;
+                }
+
+                return false;
+            }
+
+            if (contentFrame == null)
+            {
+                return false;
+            }
+
+            node.ExpandPath();
+
+            if (node.Kind == NavigationNodeKind.Action)
+            {
+                return HandleNavigationTag(node.Tag, contentFrame);
+            }
+
+            if (navigationTree != null && !ReferenceEquals(navigationTree.SelectedItem, node))
+            {
+                navigationTree.SelectedItem = node;
+                return true;
+            }
+
+            return HandleNavigationTag(node.Tag, contentFrame);
+        }
+
+        private static NavigationNode? FindNavigationNodeByTag(IEnumerable? menuItems, string navTag)
         {
             if (menuItems == null)
             {
                 return null;
             }
 
-            foreach (var item in menuItems)
+            foreach (object? item in menuItems)
             {
-                if (item is not NavigationViewItem navItem)
+                if (item is not NavigationNode navItem)
                 {
                     continue;
                 }
 
-                if (string.Equals(navItem.Tag?.ToString(), navTag, StringComparison.Ordinal))
+                if (string.Equals(navItem.Tag, navTag, StringComparison.Ordinal))
                 {
                     return navItem;
                 }
 
-                var child = FindNavigationItemByTag(navItem.MenuItems, navTag);
+                NavigationNode? child = FindNavigationNodeByTag(navItem.Children, navTag);
                 if (child != null)
                 {
                     return child;
@@ -320,13 +357,66 @@ namespace XerahS.UI.Views
             return null;
         }
 
-        private void UpdateNavigationItems(NavigationView navView)
+        private void UpdateNavigationItems()
         {
-            var captureItem = this.FindControl<NavigationViewItem>("CaptureNavItem");
-            if (captureItem == null) return;
+            if (_captureNavigationNode == null)
+            {
+                return;
+            }
 
-            // Use shared helper to update navigation items
-            NavigationItemsHelper.UpdateCaptureNavigationItems(captureItem);
+            _captureNavigationNode.ReplaceChildren(NavigationItemsHelper.CreateCaptureNavigationNodes());
+        }
+
+        private static NavigationNode CreateNode(string text, string? tag, string? glyph, NavigationNodeKind kind, bool isExpanded = false)
+        {
+            return new NavigationNode(text, tag, glyph, kind)
+            {
+                IsExpanded = isExpanded
+            };
+        }
+
+        private static NavigationNode CreateUploadNode()
+        {
+            NavigationNode uploadNode = CreateNode("Upload", "Upload", HostIcons.NavigationUpload, NavigationNodeKind.Group);
+            uploadNode.AddChild(CreateNode("Upload File...", "Upload_FileUpload", null, NavigationNodeKind.Action));
+            uploadNode.AddChild(CreateNode("Upload Content...", "Upload_ClipboardUploadWithContentViewer", null, NavigationNodeKind.Action));
+            return uploadNode;
+        }
+
+        private static NavigationNode CreateToolsNode()
+        {
+            NavigationNode toolsNode = CreateNode("Tools", "Tools", HostIcons.NavigationTools, NavigationNodeKind.Page);
+            toolsNode.AddChild(CreateNode("Color Picker...", "Tools_ColorPicker", null, NavigationNodeKind.Action));
+            toolsNode.AddChild(CreateNode("Pick From Screen", "Tools_ScreenColorPicker", null, NavigationNodeKind.Action));
+            toolsNode.AddChild(CreateNode("Ruler", "Tools_Ruler", null, NavigationNodeKind.Action));
+            toolsNode.AddChild(CreateNode("Index Folder...", "Tools_IndexFolder", null, NavigationNodeKind.Action));
+
+            NavigationNode qrCodeNode = CreateNode("QR Code", null, null, NavigationNodeKind.Group);
+            qrCodeNode.AddChild(CreateNode("Generator...", "Tools_QrGenerator", null, NavigationNodeKind.Action));
+            qrCodeNode.AddChild(CreateNode("Scan from screen", "Tools_QrScanScreen", null, NavigationNodeKind.Action));
+            qrCodeNode.AddChild(CreateNode("Scan from region", "Tools_QrScanRegion", null, NavigationNodeKind.Action));
+            toolsNode.AddChild(qrCodeNode);
+
+            toolsNode.AddChild(CreateNode("Image Combiner...", "Tools_ImageCombiner", null, NavigationNodeKind.Action));
+            toolsNode.AddChild(CreateNode("Image Splitter...", "Tools_ImageSplitter", null, NavigationNodeKind.Action));
+            toolsNode.AddChild(CreateNode("Image Thumbnailer...", "Tools_ImageThumbnailer", null, NavigationNodeKind.Action));
+#if DEBUG
+            toolsNode.AddChild(CreateNode("Video Editor...", "Tools_VideoEditor", null, NavigationNodeKind.Action));
+#endif
+            toolsNode.AddChild(CreateNode("Video Converter...", "Tools_VideoConverter", null, NavigationNodeKind.Action));
+            toolsNode.AddChild(CreateNode("Video Thumbnailer...", "Tools_VideoThumbnailer", null, NavigationNodeKind.Action));
+            toolsNode.AddChild(CreateNode("Analyze Image...", "Tools_AnalyzeImage", null, NavigationNodeKind.Action));
+            toolsNode.AddChild(CreateNode("Monitor Test", "Tools_MonitorTest", null, NavigationNodeKind.Action));
+
+            return toolsNode;
+        }
+
+        private static NavigationNode CreateSettingsNode()
+        {
+            NavigationNode settingsNode = CreateNode("Settings", "Settings", HostIcons.NavigationSettings, NavigationNodeKind.Page, isExpanded: true);
+            settingsNode.AddChild(CreateNode("Application Settings", "Settings_App", null, NavigationNodeKind.Page));
+            settingsNode.AddChild(CreateNode("Destination Settings", "Settings_Dest", null, NavigationNodeKind.Page));
+            return settingsNode;
         }
     }
 }

--- a/src/desktop/app/XerahS.UI/Views/MainWindow.axaml
+++ b/src/desktop/app/XerahS.UI/Views/MainWindow.axaml
@@ -3,7 +3,6 @@
         xmlns:vm="using:XerahS.UI.ViewModels"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:ui="using:FluentAvalonia.UI.Controls"
         xmlns:hotkeys="using:XerahS.Core.Hotkeys"
         xmlns:views="using:XerahS.UI.Views"
         xmlns:common="clr-namespace:XerahS.Common;assembly=XerahS.Common"
@@ -132,148 +131,58 @@
         </Border>
 
         <!-- Main Navigation Shell -->
-        <ui:NavigationView Grid.Row="1"
-                           Name="NavView"
-                           PaneDisplayMode="Left"
-                           IsPaneOpen="True"
-                           IsSettingsVisible="False"
-                           SelectionChanged="OnNavSelectionChanged"
-                           ItemInvoked="OnNavItemInvoked"
-                           AutomationProperties.Name="Main Navigation">
-            <ui:NavigationView.MenuItems>
-                <!-- Capture Section - Items populated dynamically from first 3 workflows -->
-                <ui:NavigationViewItem Content="Capture" Tag="Capture" SelectsOnInvoked="False" IsExpanded="True" Name="CaptureNavItem"
-                                       AutomationProperties.Name="Capture Menu">
-                    <ui:NavigationViewItem.IconSource>
-                        <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                           FontSize="18"
-                                           FontWeight="Normal"
-                                           Glyph="{x:Static theming:HostIcons.NavigationCapture}"/>
-                    </ui:NavigationViewItem.IconSource>
-                </ui:NavigationViewItem>
-                
-                <ui:NavigationViewItem Content="Recording" Tag="Recording" AutomationProperties.Name="Recording View">
-                    <ui:NavigationViewItem.IconSource>
-                        <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                           FontSize="18"
-                                           FontWeight="Normal"
-                                           Glyph="{x:Static theming:HostIcons.NavigationRecording}"/>
-                    </ui:NavigationViewItem.IconSource>
-                </ui:NavigationViewItem>
-                
-                <ui:NavigationViewItem Content="Editor" Tag="Editor" IsSelected="True" AutomationProperties.Name="Editor View">
-                    <ui:NavigationViewItem.IconSource>
-                        <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                           FontSize="18"
-                                           FontWeight="Normal"
-                                           Glyph="{x:Static theming:HostIcons.NavigationEditor}"/>
-                    </ui:NavigationViewItem.IconSource>
-                </ui:NavigationViewItem>
-                
-                <ui:NavigationViewItem Content="History" Tag="History" AutomationProperties.Name="History View">
-                    <ui:NavigationViewItem.IconSource>
-                        <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                           FontSize="18"
-                                           FontWeight="Normal"
-                                           Glyph="{x:Static theming:HostIcons.NavigationHistory}"/>
-                    </ui:NavigationViewItem.IconSource>
-                </ui:NavigationViewItem>
-                
-                <ui:NavigationViewItem Content="Workflows" Tag="Workflows" AutomationProperties.Name="Workflows View">
-                    <ui:NavigationViewItem.IconSource>
-                        <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                           FontSize="18"
-                                           FontWeight="Normal"
-                                           Glyph="{x:Static theming:HostIcons.NavigationWorkflows}"/>
-                    </ui:NavigationViewItem.IconSource>
-                </ui:NavigationViewItem>
+        <SplitView Grid.Row="1"
+                   DisplayMode="Inline"
+                   IsPaneOpen="True"
+                   CompactPaneLength="0"
+                   OpenPaneLength="300">
+            <SplitView.Pane>
+                <Border Background="{DynamicResource SolidBackgroundFillColorSecondaryBrush}"
+                        BorderBrush="{DynamicResource SurfaceStrokeColorDefaultBrush}"
+                        BorderThickness="0,0,1,0">
+                    <TreeView Name="NavigationTree"
+                              Margin="12"
+                              Background="Transparent"
+                              BorderThickness="0"
+                              SelectionChanged="OnNavSelectionChanged"
+                              KeyDown="OnNavigationTreeKeyDown"
+                              AutomationProperties.Name="Main Navigation">
+                        <TreeView.ItemTemplate>
+                            <TreeDataTemplate ItemsSource="{Binding Children}">
+                                <Border Background="Transparent"
+                                        CornerRadius="8"
+                                        Padding="10,8"
+                                        Tapped="OnNavigationNodeTapped"
+                                        AutomationProperties.Name="{Binding Text}">
+                                    <Grid ColumnDefinitions="Auto,*"
+                                          ColumnSpacing="12">
+                                        <TextBlock Text="{Binding Glyph}"
+                                                   FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
+                                                   FontSize="18"
+                                                   FontWeight="Normal"
+                                                   VerticalAlignment="Center"
+                                                   IsVisible="{Binding HasGlyph}" />
+                                        <TextBlock Grid.Column="1"
+                                                   Text="{Binding Text}"
+                                                   VerticalAlignment="Center"
+                                                   TextTrimming="CharacterEllipsis" />
+                                    </Grid>
+                                </Border>
+                            </TreeDataTemplate>
+                        </TreeView.ItemTemplate>
+                        <TreeView.Styles>
+                            <Style Selector="TreeView#NavigationTree TreeViewItem">
+                                <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" />
+                            </Style>
+                        </TreeView.Styles>
+                    </TreeView>
+                </Border>
+            </SplitView.Pane>
 
-                <ui:NavigationViewItem Content="Upload" Tag="Upload" SelectsOnInvoked="False" IsExpanded="False" AutomationProperties.Name="Upload Menu">
-                    <ui:NavigationViewItem.IconSource>
-                        <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                           FontSize="18"
-                                           FontWeight="Normal"
-                                           Glyph="{x:Static theming:HostIcons.NavigationUpload}"/>
-                    </ui:NavigationViewItem.IconSource>
-                    <ui:NavigationViewItem.MenuItems>
-                        <ui:NavigationViewItem Content="Upload File..."
-                                               Tag="Upload_FileUpload"
-                                               SelectsOnInvoked="False"
-                                               AutomationProperties.Name="File Upload"/>
-                        <ui:NavigationViewItem Content="Upload Content..."
-                                               Tag="Upload_ClipboardUploadWithContentViewer"
-                                               SelectsOnInvoked="False"
-                                               AutomationProperties.Name="Upload Content"/>
-                    </ui:NavigationViewItem.MenuItems>
-                </ui:NavigationViewItem>
-                
-                <ui:NavigationViewItem Content="Tools" Tag="Tools" SelectsOnInvoked="True" IsExpanded="False" AutomationProperties.Name="Tools Menu">
-                    <ui:NavigationViewItem.IconSource>
-                        <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                           FontSize="18"
-                                           FontWeight="Normal"
-                                           Glyph="{x:Static theming:HostIcons.NavigationTools}"/>
-                    </ui:NavigationViewItem.IconSource>
-                    <ui:NavigationViewItem.MenuItems>
-                        <ui:NavigationViewItem Content="Color Picker..." Tag="Tools_ColorPicker" SelectsOnInvoked="False" AutomationProperties.Name="Color Picker Tool"/>
-                        <ui:NavigationViewItem Content="Pick From Screen" Tag="Tools_ScreenColorPicker" SelectsOnInvoked="False" AutomationProperties.Name="Screen Color Picker Tool"/>
-                        <ui:NavigationViewItem Content="Ruler" Tag="Tools_Ruler" SelectsOnInvoked="False" AutomationProperties.Name="Ruler Tool"/>
-                        <ui:NavigationViewItem Content="Index Folder..." Tag="Tools_IndexFolder" SelectsOnInvoked="False" AutomationProperties.Name="Index Folder Tool"/>
-                        <ui:NavigationViewItem Content="QR Code" SelectsOnInvoked="False" AutomationProperties.Name="QR Code Tools">
-                            <ui:NavigationViewItem.MenuItems>
-                                <ui:NavigationViewItem Content="Generator..." Tag="Tools_QrGenerator" SelectsOnInvoked="False" AutomationProperties.Name="QR Code Generator"/>
-                                <ui:NavigationViewItem Content="Scan from screen" Tag="Tools_QrScanScreen" SelectsOnInvoked="False" AutomationProperties.Name="Scan QR from Screen"/>
-                                <ui:NavigationViewItem Content="Scan from region" Tag="Tools_QrScanRegion" SelectsOnInvoked="False" AutomationProperties.Name="Scan QR from Region"/>
-                            </ui:NavigationViewItem.MenuItems>
-                        </ui:NavigationViewItem>
-                        <ui:NavigationViewItem Content="Image Combiner..." Tag="Tools_ImageCombiner" SelectsOnInvoked="False" AutomationProperties.Name="Image Combiner Tool"/>
-                        <ui:NavigationViewItem Content="Image Splitter..." Tag="Tools_ImageSplitter" SelectsOnInvoked="False" AutomationProperties.Name="Image Splitter Tool"/>
-                        <ui:NavigationViewItem Content="Image Thumbnailer..." Tag="Tools_ImageThumbnailer" SelectsOnInvoked="False" AutomationProperties.Name="Image Thumbnailer Tool"/>
-                        <ui:NavigationViewItem Name="NavItemVideoEditor" Content="Video Editor..." Tag="Tools_VideoEditor" SelectsOnInvoked="False" AutomationProperties.Name="Video Editor Tool"/>
-                        <ui:NavigationViewItem Content="Video Converter..." Tag="Tools_VideoConverter" SelectsOnInvoked="False" AutomationProperties.Name="Video Converter Tool"/>
-                        <ui:NavigationViewItem Content="Video Thumbnailer..." Tag="Tools_VideoThumbnailer" SelectsOnInvoked="False" AutomationProperties.Name="Video Thumbnailer Tool"/>
-                        <ui:NavigationViewItem Content="Analyze Image..." Tag="Tools_AnalyzeImage" SelectsOnInvoked="False" AutomationProperties.Name="Image Analyzer Tool"/>
-                        <ui:NavigationViewItem Content="Monitor Test" Tag="Tools_MonitorTest" SelectsOnInvoked="False" AutomationProperties.Name="Monitor Test Tool"/>
-                    </ui:NavigationViewItem.MenuItems>
-                </ui:NavigationViewItem>
-                
-                <ui:NavigationViewItem Content="Settings" Tag="Settings" SelectsOnInvoked="True" IsExpanded="True" AutomationProperties.Name="Settings Menu">
-                    <ui:NavigationViewItem.IconSource>
-                        <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                           FontSize="18"
-                                           FontWeight="Normal"
-                                           Glyph="{x:Static theming:HostIcons.NavigationSettings}"/>
-                    </ui:NavigationViewItem.IconSource>
-                    <ui:NavigationViewItem.MenuItems>
-                        <ui:NavigationViewItem Content="Application Settings" Tag="Settings_App" AutomationProperties.Name="Application Settings"/>
-                        <ui:NavigationViewItem Content="Destination Settings" Tag="Settings_Dest" AutomationProperties.Name="Destination Settings"/>
-                    </ui:NavigationViewItem.MenuItems>
-                 </ui:NavigationViewItem>
-                 
-                 <ui:NavigationViewItem Content="Debug" Tag="Debug" AutomationProperties.Name="Debug View"
-                                        AutomationProperties.HelpText="Opens developer debug tools">
-                    <ui:NavigationViewItem.IconSource>
-                        <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                           FontSize="18"
-                                           FontWeight="Normal"
-                                           Glyph="{x:Static theming:HostIcons.NavigationDebug}"/>
-                    </ui:NavigationViewItem.IconSource>
-                 </ui:NavigationViewItem>
-
-                <ui:NavigationViewItem Content="About" Tag="About" AutomationProperties.Name="About View">
-                    <ui:NavigationViewItem.IconSource>
-                        <ui:FontIconSource FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                           FontSize="18"
-                                           FontWeight="Normal"
-                                           Glyph="{x:Static theming:HostIcons.NavigationAbout}"/>
-                    </ui:NavigationViewItem.IconSource>
-                </ui:NavigationViewItem>
-            </ui:NavigationView.MenuItems>
-            
-            <ui:NavigationView.Content>
-                 <ContentControl Name="ContentFrame" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch"/>
-            </ui:NavigationView.Content>
-        </ui:NavigationView>
+            <TransitioningContentControl Name="ContentFrame"
+                                         HorizontalContentAlignment="Stretch"
+                                         VerticalContentAlignment="Stretch" />
+        </SplitView>
 
         <!-- Modal Overlay Layer (Bootstrap Style) -->
         <Grid Grid.Row="0" Grid.RowSpan="2" 

--- a/src/desktop/app/XerahS.UI/Views/MainWindow.axaml.cs
+++ b/src/desktop/app/XerahS.UI/Views/MainWindow.axaml.cs
@@ -26,7 +26,6 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 using Avalonia.Platform.Storage;
-using FluentAvalonia.UI.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Threading;
@@ -65,6 +64,7 @@ namespace XerahS.UI.Views
         /// Collection of user-configured workflows for menu binding.
         /// </summary>
         public ObservableCollection<WorkflowSettings> UserWorkflows { get; } = new ObservableCollection<WorkflowSettings>();
+        public ObservableCollection<NavigationNode> NavigationNodes { get; } = new ObservableCollection<NavigationNode>();
 
         public MainWindow()
         {
@@ -77,28 +77,22 @@ namespace XerahS.UI.Views
             var menuItemVideoEditor = this.FindControl<MenuItem>("MenuItemVideoEditor");
             if (menuItemVideoEditor != null)
                 menuItemVideoEditor.IsVisible = false;
-            var navItemVideoEditor = this.FindControl<NavigationViewItem>("NavItemVideoEditor");
-            if (navItemVideoEditor != null)
-                navItemVideoEditor.IsVisible = false;
 #endif
 
             // Set initial theme and subscribe to changes
             RequestedThemeVariant = ThemeManager.GetCurrentTheme();
             ThemeManager.ThemeChanged += (s, theme) => RequestedThemeVariant = theme;
 
-            // Initial Navigation
-            var navView = this.FindControl<NavigationView>("NavView");
-            if (navView != null)
+            BuildNavigationNodes();
+
+            var navigationTree = this.FindControl<TreeView>("NavigationTree");
+            if (navigationTree != null)
             {
-                // Force selection of first item
-                if (navView.MenuItems[0] is NavigationViewItem item)
-                {
-                    navView.SelectedItem = item;
-                    OnNavSelectionChanged(navView, new NavigationViewSelectionChangedEventArgs());
-                }
+                navigationTree.ItemsSource = NavigationNodes;
             }
 
             LoadUserWorkflows();
+            NavigateTo("Editor");
         }
 
         protected override void OnDataContextChanged(EventArgs e)
@@ -389,12 +383,7 @@ namespace XerahS.UI.Views
                 XerahS.Common.DebugHelper.WriteException(ex, "MainWindow: NotifyWindowReady failed");
             }
 
-            // Update navigation items after settings are loaded
-            var navView = this.FindControl<NavigationView>("NavView");
-            if (navView != null)
-            {
-                UpdateNavigationItems(navView);
-            }
+            UpdateNavigationItems();
 
             LoadUserWorkflows();
 
@@ -406,10 +395,7 @@ namespace XerahS.UI.Views
                     {
                         LoadUserWorkflows();
 
-                        if (navView != null)
-                        {
-                            UpdateNavigationItems(navView);
-                        }
+                        UpdateNavigationItems();
                     });
                 };
             }

--- a/src/desktop/app/XerahS.UI/Views/RecordingToolbarView.axaml
+++ b/src/desktop/app/XerahS.UI/Views/RecordingToolbarView.axaml
@@ -1,7 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:XerahS.UI.ViewModels"
-             xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:theming="clr-namespace:ShareX.ImageEditor.Presentation.Theming;assembly=ShareX.ImageEditor"
              mc:Ignorable="d" d:DesignWidth="420" d:DesignHeight="60"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -77,10 +76,9 @@
                         ToolTip.Tip="Start Recording"
                         AutomationProperties.Name="Start Recording">
                     <StackPanel Orientation="Horizontal" Spacing="8">
-                        <ui:FontIcon FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                     FontSize="16"
-                                     FontWeight="Normal"
-                                     Glyph="{x:Static theming:HostIcons.ActionStart}"/>
+                        <TextBlock Classes="IconGlyph"
+                                   FontSize="16"
+                                   Text="{x:Static theming:HostIcons.ActionStart}"/>
                         <TextBlock Text="Start" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>
@@ -92,10 +90,9 @@
                         ToolTip.Tip="Stop Recording"
                         AutomationProperties.Name="Stop Recording">
                     <StackPanel Orientation="Horizontal" Spacing="8">
-                        <ui:FontIcon FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                     FontSize="16"
-                                     FontWeight="Normal"
-                                     Glyph="{x:Static theming:HostIcons.ActionStop}"/>
+                        <TextBlock Classes="IconGlyph"
+                                   FontSize="16"
+                                   Text="{x:Static theming:HostIcons.ActionStop}"/>
                         <TextBlock Text="Stop" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>
@@ -106,10 +103,9 @@
                         ToolTip.Tip="Pause Recording"
                         AutomationProperties.Name="Pause Recording">
                     <StackPanel Orientation="Horizontal" Spacing="8">
-                        <ui:FontIcon FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                     FontSize="16"
-                                     FontWeight="Normal"
-                                     Glyph="{x:Static theming:HostIcons.ActionPause}"/>
+                        <TextBlock Classes="IconGlyph"
+                                   FontSize="16"
+                                   Text="{x:Static theming:HostIcons.ActionPause}"/>
                         <TextBlock Text="Pause" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>
@@ -120,10 +116,9 @@
                         ToolTip.Tip="Resume Recording"
                         AutomationProperties.Name="Resume Recording">
                     <StackPanel Orientation="Horizontal" Spacing="8">
-                        <ui:FontIcon FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                     FontSize="16"
-                                     FontWeight="Normal"
-                                     Glyph="{x:Static theming:HostIcons.ActionResume}"/>
+                        <TextBlock Classes="IconGlyph"
+                                   FontSize="16"
+                                   Text="{x:Static theming:HostIcons.ActionResume}"/>
                         <TextBlock Text="Resume" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>
@@ -134,10 +129,9 @@
                         ToolTip.Tip="Abort Recording"
                         AutomationProperties.Name="Abort Recording">
                     <StackPanel Orientation="Horizontal" Spacing="8">
-                        <ui:FontIcon FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                     FontSize="16"
-                                     FontWeight="Normal"
-                                     Glyph="{x:Static theming:HostIcons.ActionAbort}"/>
+                        <TextBlock Classes="IconGlyph"
+                                   FontSize="16"
+                                   Text="{x:Static theming:HostIcons.ActionAbort}"/>
                         <TextBlock Text="Abort" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>

--- a/src/desktop/app/XerahS.UI/Views/RecordingView.axaml
+++ b/src/desktop/app/XerahS.UI/Views/RecordingView.axaml
@@ -4,7 +4,6 @@
              xmlns:views="using:XerahS.UI.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:theming="clr-namespace:ShareX.ImageEditor.Presentation.Theming;assembly=ShareX.ImageEditor"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="800"
              x:Class="XerahS.UI.Views.RecordingView"
@@ -143,11 +142,10 @@
                                 CornerRadius="4"
                                 Padding="12,8">
                             <StackPanel Spacing="8" Orientation="Horizontal">
-                                <ui:FontIcon FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                             FontSize="16"
-                                             FontWeight="Normal"
-                                             Foreground="{DynamicResource SystemFillColorAttentionBrush}"
-                                             Glyph="{x:Static theming:HostIcons.StatusWarning}"/>
+                                <TextBlock Classes="IconGlyph"
+                                           FontSize="16"
+                                           Foreground="{DynamicResource SystemFillColorAttentionBrush}"
+                                           Text="{x:Static theming:HostIcons.StatusWarning}"/>
                                 <TextBlock Text="{Binding EncoderInfo}"
                                            Theme="{StaticResource CaptionTextBlockStyle}"
                                            TextWrapping="Wrap"

--- a/src/desktop/app/XerahS.UI/Views/SettingsView.axaml
+++ b/src/desktop/app/XerahS.UI/Views/SettingsView.axaml
@@ -3,7 +3,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:XerahS.UI.ViewModels"
-             xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:common="clr-namespace:XerahS.Common;assembly=XerahS.Common"
              xmlns:theming="clr-namespace:ShareX.ImageEditor.Presentation.Theming;assembly=ShareX.ImageEditor"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
@@ -16,11 +15,10 @@
 
     <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="24" MaxWidth="420">
-            <ui:FontIcon FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                         FontSize="64"
-                         FontWeight="Normal"
-                         Foreground="{DynamicResource AccentFillColorDefaultBrush}"
-                         Glyph="{x:Static theming:HostIcons.NavigationSettings}"/>
+            <TextBlock Classes="IconGlyph"
+                       FontSize="64"
+                       Foreground="{DynamicResource AccentFillColorDefaultBrush}"
+                       Text="{x:Static theming:HostIcons.NavigationSettings}"/>
             
             <StackPanel Spacing="8">
                 <TextBlock Text="{Binding Source={x:Static common:AppResources.AppName}, StringFormat='{}{0} Settings'}" 

--- a/src/desktop/app/XerahS.UI/Views/ToolsView.axaml
+++ b/src/desktop/app/XerahS.UI/Views/ToolsView.axaml
@@ -2,7 +2,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:common="clr-namespace:XerahS.Common;assembly=XerahS.Common"
              xmlns:theming="clr-namespace:ShareX.ImageEditor.Presentation.Theming;assembly=ShareX.ImageEditor"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
@@ -10,11 +9,10 @@
 
     <Grid>
         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="24">
-            <ui:FontIcon FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                         FontSize="64"
-                         FontWeight="Normal"
-                         Foreground="{DynamicResource AccentFillColorDefaultBrush}"
-                         Glyph="{x:Static theming:HostIcons.NavigationTools}"/>
+            <TextBlock Classes="IconGlyph"
+                       FontSize="64"
+                       Foreground="{DynamicResource AccentFillColorDefaultBrush}"
+                       Text="{x:Static theming:HostIcons.NavigationTools}"/>
 
             <StackPanel Spacing="8">
                 <TextBlock Text="{Binding Source={x:Static common:AppResources.AppName}, StringFormat='{}{0} Tools'}"

--- a/src/desktop/app/XerahS.UI/Views/WorkflowsView.axaml
+++ b/src/desktop/app/XerahS.UI/Views/WorkflowsView.axaml
@@ -4,7 +4,6 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:XerahS.UI.ViewModels"
              xmlns:controls="using:XerahS.UI.Views.Controls"
-             xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:theming="clr-namespace:ShareX.ImageEditor.Presentation.Theming;assembly=ShareX.ImageEditor"
              mc:Ignorable="d" d:DesignWidth="1000" d:DesignHeight="600"
              x:Class="XerahS.UI.Views.WorkflowsView"
@@ -20,15 +19,14 @@
                 
                 <Button Command="{Binding AddWorkflowCommand}" ToolTip.Tip="Add New Workflow" AutomationProperties.Name="Add New Workflow">
                     <StackPanel Orientation="Horizontal" Spacing="8">
-                        <ui:FontIcon FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                     FontSize="16"
-                                     FontWeight="Normal"
-                                     Glyph="{x:Static theming:HostIcons.ActionAdd}"/>
+                        <TextBlock Classes="IconGlyph"
+                                   FontSize="16"
+                                   Text="{x:Static theming:HostIcons.ActionAdd}"/>
                         <TextBlock Text="Add New"/>
                     </StackPanel>
                 </Button>
                 
-                <ui:CommandBarSeparator />
+                <Separator Classes="ToolbarSeparator" />
                 
                 <Button Content="Edit" Command="{Binding EditWorkflowCommand}" 
                         IsEnabled="{Binding SelectedWorkflow, Converter={x:Static ObjectConverters.IsNotNull}}"
@@ -52,27 +50,25 @@
                         MinWidth="120"
                         AutomationProperties.Name="Toggle Pin"/>    
                 
-                <ui:CommandBarSeparator />
+                <Separator Classes="ToolbarSeparator" />
 
                 <Button Command="{Binding MoveUpCommand}" ToolTip.Tip="Move Up"
                         IsEnabled="{Binding SelectedWorkflow, Converter={x:Static ObjectConverters.IsNotNull}}"
                         AutomationProperties.Name="Move Up">
-                    <ui:FontIcon FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                 FontSize="16"
-                                 FontWeight="Normal"
-                                 Glyph="{x:Static theming:HostIcons.ActionMoveUp}"/>
+                    <TextBlock Classes="IconGlyph"
+                               FontSize="16"
+                               Text="{x:Static theming:HostIcons.ActionMoveUp}"/>
                 </Button>
 
                 <Button Command="{Binding MoveDownCommand}" ToolTip.Tip="Move Down"
                         IsEnabled="{Binding SelectedWorkflow, Converter={x:Static ObjectConverters.IsNotNull}}"
                         AutomationProperties.Name="Move Down">
-                    <ui:FontIcon FontFamily="{DynamicResource ShareX.FontFamily.Icon}"
-                                 FontSize="16"
-                                 FontWeight="Normal"
-                                 Glyph="{x:Static theming:HostIcons.ActionMoveDown}"/>
+                    <TextBlock Classes="IconGlyph"
+                               FontSize="16"
+                               Text="{x:Static theming:HostIcons.ActionMoveDown}"/>
                 </Button>
                 
-                <ui:CommandBarSeparator />
+                <Separator Classes="ToolbarSeparator" />
 
                 <Button Command="{Binding ResetCommand}" 
                         ToolTip.Tip="Reset to Defaults" 

--- a/src/desktop/app/XerahS.UI/Views/WorkflowsView.axaml.cs
+++ b/src/desktop/app/XerahS.UI/Views/WorkflowsView.axaml.cs
@@ -26,6 +26,7 @@ using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using XerahS.Common;
 using XerahS.UI.ViewModels;
+using XerahS.UI.Views.Dialogs;
 
 namespace XerahS.UI.Views;
 
@@ -63,19 +64,10 @@ public partial class WorkflowsView : UserControl
         vm.ConfirmByUi = async (title, message) =>
         {
             DebugHelper.WriteLine($"[WorkflowsView] ConfirmByUi called. Title={title}");
-            var dialog = new FluentAvalonia.UI.Controls.ContentDialog
-            {
-                Title = title,
-                Content = message,
-                PrimaryButtonText = "Yes",
-                CloseButtonText = "No",
-                DefaultButton = FluentAvalonia.UI.Controls.ContentDialogButton.Close
-            };
-
             if (VisualRoot is Window window)
             {
-                var result = await dialog.ShowAsync();
-                return result == FluentAvalonia.UI.Controls.ContentDialogResult.Primary;
+                var dialog = new ConfirmationDialog(title, message);
+                return await dialog.ShowDialog<bool>(window);
             }
 
             return false;

--- a/src/desktop/app/XerahS.UI/XerahS.UI.csproj
+++ b/src/desktop/app/XerahS.UI/XerahS.UI.csproj
@@ -15,11 +15,11 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Controls.ColorPicker" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
     <PackageReference Include="AvaloniaUI.DiagnosticsSupport" />
     <PackageReference Include="CommunityToolkit.Mvvm" />
-    <PackageReference Include="FluentAvaloniaUI" />
     <PackageReference Include="SkiaSharp" />
 
   </ItemGroup>


### PR DESCRIPTION
This pull request completes the migration from the third-party `FluentAvaloniaUI` package to the official Avalonia `FluentTheme` and primitives. It removes the dependency on `FluentAvaloniaUI`, updates theming and resource integration, and refactors navigation helpers to use a new, viewmodel-based navigation node system. Documentation is also updated to reflect the new approach to context menus and theming, clarifying that `ContextMenu` is now fully supported. The most important changes are outlined below.

**Theme and Dependency Migration:**

* Removed the `FluentAvaloniaUI` package and all usages, replacing it with the official Avalonia `FluentTheme` in `XerahS.UI` (`Directory.Packages.props`, `App.axaml`). [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L22) [[2]](diffhunk://#diff-656907eea9d3c30ac006ce516a532567323050645f8f0db5ce6b702a9848f0b5L8) [[3]](diffhunk://#diff-656907eea9d3c30ac006ce516a532567323050645f8f0db5ce6b702a9848f0b5L83-R91)
* Added a new `Compatibility.axaml` resource dictionary to bridge theming gaps and provide custom styles and brushes previously supplied by FluentAvalonia. [[1]](diffhunk://#diff-ebdf26586fcf1d3158b8bea08e5f3eb8c13333a704e8c8fc628bbf916878a69dR1-R58) [[2]](diffhunk://#diff-656907eea9d3c30ac006ce516a532567323050645f8f0db5ce6b702a9848f0b5R16-R20) [[3]](diffhunk://#diff-656907eea9d3c30ac006ce516a532567323050645f8f0db5ce6b702a9848f0b5R63) [[4]](diffhunk://#diff-656907eea9d3c30ac006ce516a532567323050645f8f0db5ce6b702a9848f0b5L83-R91)

**Navigation Refactor:**

* Introduced a new `NavigationNode` viewmodel class to represent navigation structure, replacing direct UI control manipulation in navigation helpers. [[1]](diffhunk://#diff-e2bf285753a64d489ae6088f0fec59be885e2507e4d33a2d44dbddee296cce61R1-R91) [[2]](diffhunk://#diff-523dbe1ab5954d09d57d211e3ad6e648d300356a4a7cda884203b4120b024ee5L27-R29) [[3]](diffhunk://#diff-523dbe1ab5954d09d57d211e3ad6e648d300356a4a7cda884203b4120b024ee5L69-R82)

**Documentation and Lessons Update:**

* Updated developer documentation to clarify that `ContextMenu` is now viable with the official theme, and rewrote the lesson about context menus and flyouts to reflect this change.
* Enhanced the migration proposal to include secondary benefits, a checklist for simplifying flyout usage, and updated acceptance criteria and references regarding context menus and flyouts. [[1]](diffhunk://#diff-717a9c61261db5a6081a7909ff122d95c0200276f97b601b84e51ac04b5b5a51R11-R16) [[2]](diffhunk://#diff-717a9c61261db5a6081a7909ff122d95c0200276f97b601b84e51ac04b5b5a51R147-R156) [[3]](diffhunk://#diff-717a9c61261db5a6081a7909ff122d95c0200276f97b601b84e51ac04b5b5a51R330) [[4]](diffhunk://#diff-717a9c61261db5a6081a7909ff122d95c0200276f97b601b84e51ac04b5b5a51L375-R398)