### PR TITLE
Blog post content updates

### DIFF
--- a/docs/blog/2026/2026-03/blog-20260314.md
+++ b/docs/blog/2026/2026-03/blog-20260314.md
@@ -6,27 +6,34 @@ Status: Draft
 
 ## Summary
 
-March 14 focused on Linux capture behavior, especially X11 systems where a modern region path may exist on paper but still hang, fail, or route through the wrong selector at runtime. XerahS restored reliable X11 fallback behavior, taught the Linux capture stack to preserve native modern paths only when the session is genuinely capable, and then started the `XIP0051` UX work so Linux users can choose an interactive region selector directly instead of relying on the vague `UseModernCapture` checkbox. ShareX.ImageEditor moved in parallel with editor UX cleanup around context menus, close handling, keyboard routing, and exit confirmation.
+March 14 started with a deep Linux capture pass in XerahS. X11 region capture regained a safe overlay fallback path, capable X11 desktops kept their native or portal-backed selector when the runtime really supported it, and `XIP0051` plus new settings UI reframed Linux selector choice as an explicit preference instead of overloading `UseModernCapture`.
+
+Later in the day, the focus widened into host and editor integration polish. XerahS tightened hotkey and theme contrast, published native Windows clipboard image formats, moved annotate task controls back into the host, and ran a broad surface-compatibility sweep across tool windows, while ShareX.ImageEditor cleaned up close handling, keyboard routing, exit confirmation, and its editor context menu.
 
 ## Features
 
-- Added the `XIP0051` proposal for Linux interactive region selector preferences, documenting the Linux capture stack in terms of session protocol, desktop environment, compositor, portal backend, and selector provider.
-- Added Linux selector preference plumbing plus app-level and task-level settings UI so interactive region selection can move toward explicit Linux-specific choices instead of a generic modern-capture toggle.
-- Added an `ExitConfirmation` option in ShareX.ImageEditor and made task buttons and continue/cancel hints more explicit during editor workflows.
+- Added the `XIP0051` proposal and the supporting Linux selector preference model, diagnostics, and app-level/task-level settings UI so Linux users can choose interactive region selectors more explicitly.
+- Added host-owned annotate editor task buttons in XerahS and wired annotate continuation through desktop and headless UI services, keeping task workflow ownership in the main app instead of the shared editor.
+- ShareX.ImageEditor added exit confirmation, parent-window key routing, and clearer task button tooltip/key hints while moving the editor menu onto a `ContextMenu`-based implementation.
 
 ## Fixes
 
-- Restored Linux X11 region capture fallbacks so systems with old or incomplete modern capture support drop back to the XerahS crosshair overlay instead of timing out or returning no region.
-- Preserved capable X11 modern capture by detecting desktop and portal capabilities more carefully, then adjusting the provider waterfall so reliable native or portal-backed selectors stay available where they actually work.
-- Simplified ShareX.ImageEditor close and result handling, attached key handlers to the parent window so shortcuts survive focus changes, and moved the editor context menu onto a styled `ContextMenu`-based implementation.
+- Restored Linux X11 region capture fallbacks so unsupported or failing modern paths drop back to the XerahS overlay instead of timing out or returning no region.
+- Preserved capable X11 modern region capture by checking desktop and portal backend signals more carefully, so native selectors stay available where they are actually reliable.
+- Published native Windows clipboard image formats and added coverage around the clipboard helper path, improving interoperability with Windows clipboard consumers.
+- Normalized hotkey card surfaces, toolbar contrast, themed text brushes, shared container surfaces, tool window hosts, and Fluent compatibility brushes so desktop views paint more consistently across themes.
+- ShareX.ImageEditor centralized close/result handling, attached key handlers to the parent window so shortcuts survive focus changes, and briefly experimented with task-mode continuation before reverting the host-specific button ownership back toward XerahS.
 
 ## Build and Tooling
 
-- Bumped XerahS version metadata from `0.20.2` to `0.20.3` while the Linux selector and capture-stack work landed.
-- Added Linux capture diagnostics, capability detection, and orchestration test coverage around selector preference, X11 fallback behavior, and portal/backend ordering.
-- Recorded new lessons learnt for Linux capture fallbacks, X11 portal guardrails, and selector UX so future Linux work can build on the same decision trail.
+- Bumped XerahS version metadata from `0.20.2` to `0.20.3` in `Directory.Build.props`.
+- Added Linux capture orchestration coverage around fallback behavior, portal/backend ordering, selector diagnostics, and selector preference plumbing.
+- Added Windows clipboard helper tests alongside the native clipboard image format work.
+- Recorded Linux capture fallback lessons, X11 portal guardrails, and Linux selector UX guidance, and documented the selector direction in `XIP0051`.
 
 ## Commits Reviewed
+
+XerahS:
 
 - `a510da3f` `[v0.20.2] [Fix] Restore Linux X11 region capture fallbacks`
 - `435fb58d` `[v0.20.2] [Docs] Record Linux capture fallback lessons`
@@ -39,13 +46,36 @@ March 14 focused on Linux capture behavior, especially X11 systems where a moder
 - `f68f6300` `[v0.20.3] [Docs] Record Linux selector UX lessons`
 - `3852768d` `[v0.20.3] [Refactor] Replace Linux UseModernCapture semantics`
 - `94e4d020` `[v0.20.3] [Update] Clarify Linux capture settings UI`
+- `ec599b8b` `[v0.20.2] [Fix] Normalize hotkey control card surfaces`
+- `05d73905` `[v0.20.2] [Fix] Improve hotkey toolbar contrast`
+- `4268d657` `[v0.20.2] [Fix] Map primary text brush to theme`
+- `dee46e8d` `[v0.20.2] [Fix] Make hotkey move labels explicit`
+- `43bbccbe` `[v0.20.3] [Fix] Publish native Windows clipboard image formats`
+- `a5be14e6` `[v0.20.2] [UI] Hide editor task buttons in XerahS hosts`
+- `5560ea1b` `[v0.20.2] [Workflow] Wire annotate editor task actions`
+- `5809651a` `[v0.20.2] [Workflow] Keep annotate editor task UI in XerahS`
+- `0fbada88` `[v0.20.2] [Refactor] Unify shared container surfaces`
+- `0bffed33` `[v0.20.2] [UI] Hide task buttons in main editor host`
+- `b2e17ebd` `[v0.20.2] [Refactor] Expand theme surface compatibility`
+- `19b4424f` `[v0.20.2] [Fix] Normalize tool window surfaces`
+- `68ff55e9` `[v0.20.2] [Refactor] Move window surfaces into host bases`
+- `637899a7` `[v0.20.2] [Fix] Detach window content before wrapping`
+- `57f55361` `[v0.20.2] [Fix] Expand shared Fluent surface bridge`
+
+ShareX.ImageEditor:
+
 - `148315e` `Show task buttons always; dynamic tooltip & keys`
 - `86171ef` `Use ContextMenu for editor context menu`
 - `dbc349d` `Centralize close logic and simplify result handling`
 - `0eb6bfa` `Attach key handlers to parent window`
 - `3acce65` `Add ExitConfirmation option and respect on close`
+- `249c066` `[UI] Hide task mode buttons in XerahS hosts`
+- `02bdf1b` `[UI] Support task-mode editor continuation`
+- `0e7d753` `Revert "[UI] Support task-mode editor continuation"`
+- `0de194f` `Revert "[UI] Hide task mode buttons in XerahS hosts"`
 
 ## Notes
 
-- This is the first user-facing slice of the Linux selector preference work. Cross-desktop validation is still important across GNOME, KDE, Cinnamon/XApp, and wlroots-style environments because the new logic is deliberately capability-driven.
-- ShareX.ImageEditor iterated quickly on context-menu behavior during the same UTC+8 day, so future editor syncs should keep an eye on styling and shortcut regressions after the switch to `ContextMenu` and the close-flow cleanup.
+- XerahS.Editor was checked for this UTC+8 day and had no commits.
+- This was the first user-facing slice of the Linux selector preference work. Cross-desktop validation is still important across GNOME, KDE, Cinnamon/XApp, and wlroots-style environments because the new routing is intentionally capability-driven.
+- The annotate-task integration changed direction during the same day: ShareX.ImageEditor briefly tried to own more of the task-mode behavior, then backed that out while XerahS kept the host-side task UI.

--- a/docs/blog/2026/2026-03/blog-20260315.md
+++ b/docs/blog/2026/2026-03/blog-20260315.md
@@ -6,74 +6,90 @@ Status: Draft
 
 ## Summary
 
-March 15 focused on theme consistency and tool-window reliability across XerahS and ShareX.ImageEditor. XerahS centralized desktop theme styles, applied accent buttons and scrollbars app-wide, and fixed root-surface painting for every tool window (image combiner, splitter, thumbnailer, video converter, color picker, hash check, index folder, and video tool) so they respect the active theme. ShareX.ImageEditor added a task-mode button visibility option, enabled zoom and Copy only when an image is loaded, introduced semantic status palette tokens, and aligned move-up/move-down icons with the host. Editor integration and tools navigation were updated in XerahS and the ImageEditor submodule was refreshed to match.
+March 15 opened with a broad theme and tool-window polish pass across XerahS and ShareX.ImageEditor. XerahS centralized desktop theme styles, fixed root-surface painting across the tool windows, standardized accent buttons and scrollbar behavior, and tightened editor integration so command availability and host navigation feel more coherent.
+
+The second half of the day shifted toward Linux capture correctness and contributor workflow. Selector preference handling was hardened, workflow edits became staged until save, region-capture modifier and portal hotkey cleanup closed correctness gaps, and diagnostics started surfacing the last runtime selector decision. Release and documentation work rounded the day out with `v0.20.4`, daily blog scheduling guidance, skill renames for discoverability, and the initial `XIP0052` proposal.
 
 ## Features
 
-- Sorted the View Zoom menu alphabetically and enabled zoom commands only when an image is loaded in the editor (XerahS and ShareX.ImageEditor).
-- Show File Save and Save As only when an image is loaded in the editor.
-- ShareX.ImageEditor: added task mode button visibility option; disabled Edit Copy to Clipboard when no image is loaded; added semantic status palette tokens for consistent theming.
+- Kept editor commands visible while disabling them when no image is loaded: Zoom, Copy, and Save/Save As now communicate availability without hiding menu entries.
+- ShareX.ImageEditor added a task-mode button visibility option and semantic status palette tokens so hosts can tune the editor chrome while keeping status colors more consistent.
+- Created the initial `XIP0052` proposal for agentic refactoring.
 
 ## Fixes
 
-- Painted tool window root surfaces and gutters correctly so theme backgrounds apply: video tool, image thumbnailer, splitter, combiner, analyzer, color picker, hash check window, and index folder surfaces (XerahS).
-- Applied accent button style app-wide: color picker, upload content, image and video thumbnailer, video converter, image splitter, image combiner; made accent the default button style; restored neutral scrollbars and disabled auto-hide; accent scrollbar thumbs app-wide.
-- Updated ShareX.ImageEditor move-up and move-down icons to match the host; XerahS submodule updated to use the new icons.
-- Placed color picker swatch tooltips above chips; widened image combiner options layout; showed workflow move button labels; kept index folder controls visible.
+- Painted tool window root surfaces and gutters correctly across the video tool, image thumbnailer, splitter, combiner, analyzer, color picker, hash check window, and index folder so theme backgrounds apply consistently.
+- Applied accent button styling more consistently across the desktop tools, restored neutral scrollbars while keeping accent thumbs, and centralized theme resource defaults to reduce drift between windows.
+- Updated ShareX.ImageEditor move-up and move-down icons to match the host, placed color picker swatch tooltips above the chips, widened the image combiner options layout, showed workflow move button labels, and kept index folder controls visible.
+- Hardened Linux selector preference handling so only valid selector choices are offered, staged workflow editor changes until save, resynced drag modifiers during region capture, drained portal hotkey rebind work before disposal, and surfaced the last runtime selector decision in diagnostics.
 
 ## Build and Tooling
 
 - Updated `run-debug-app.sh` for local debugging.
-- XerahS: removed stale editor toolbar references; updated editor integration and tools navigation. ShareX.ImageEditor: removed unused capture toolbar option.
+- Added blog scheduling documentation plus a daily wrapper script for the `draft-blog-post` skill.
+- Renamed the internal skill catalog for discoverability and refreshed related docs/tests while doing that cleanup.
+- Released `v0.20.4` and updated packaging metadata and changelog entries accordingly.
 
 ## Commits Reviewed
 
 XerahS:
 
-- `1cca79ec` `[v0.20.3] [UI] Sort View Zoom menu alphabetically; zoom enabled only with image`
-- `119d6324` `[v0.20.3] [Submodule] Update ShareX.ImageEditor: disable Copy when no image`
-- `b10a5338` `[v0.20.3] [UI] Show File Save and Save As only when image loaded in editor`
-- `4b88f19c` `[v0.20.3] [Fix] Paint video tool window surfaces`
-- `8254e13c` `[v0.20.3] [Refactor] Centralize desktop theme styles`
-- `80677704` `Update run-debug-app.sh`
-- `43b7c8f9` `[v0.20.2] [Cleanup] Remove stale editor toolbar references`
-- `9d4e09be` `[v0.20.2] [UI] Update editor integration and tools navigation`
-- `d77b4a4f` `[v0.20.3] [Fix] Restore neutral scrollbars and disable auto-hide`
-- `6895b18e` `[v0.20.3] [Refactor] Make accent the default button style`
-- `7cbeef73` `[v0.20.3] [Fix] Use accent buttons in color picker`
-- `24093641` `[v0.20.3] [Fix] Update ShareX.ImageEditor move-down icon`
-- `2b661408` `[v0.20.3] [Fix] Use accent buttons in upload content`
-- `b2bed6c1` `[v0.20.3] [Fix] Use accent buttons in image thumbnailer`
-- `553bc915` `[v0.20.3] [Fix] Use accent buttons in video thumbnailer`
-- `77eaede2` `[v0.20.3] [Fix] Use accent buttons in video converter`
-- `d2e82af6` `[v0.20.3] [Fix] Use accent buttons in image splitter`
-- `7a314245` `[v0.20.3] [Fix] Paint hash check window surface`
-- `dc6bb5ba` `[v0.20.3] [Fix] Place color picker swatch tooltips above chips`
-- `c20f703e` `[v0.20.3] [Fix] Widen image combiner options layout`
-- `7db2f3ed` `[v0.20.3] [Fix] Accent scrollbar thumbs app wide`
-- `857b192d` `[v0.20.3] [Fix] Update ShareX.ImageEditor move-up icon`
-- `2160e463` `[v0.20.3] [Fix] Use accent buttons in image combiner`
-- `17ffcb04` `[v0.20.3] [Fix] Keep index folder controls visible`
-- `550ab5f8` `[v0.20.3] [Fix] Paint image thumbnailer root surface`
-- `87946d13` `[v0.20.3] [Fix] Paint image splitter root surface`
-- `4d411ce0` `[v0.20.3] [Fix] Paint image combiner root surface`
-- `8c025fb4` `[v0.20.3] [Fix] Paint image analyzer root surface`
-- `ec782d3d` `[v0.20.3] [Fix] Paint color picker root surfaces`
-- `cca26574` `[v0.20.3] [Fix] Show workflow move button labels`
-- `e59362e7` `[v0.20.2] [Fix] Paint index folder root gutter`
 - `5a7ea131` `[v0.20.2] [Fix] Paint index folder surfaces explicitly`
+- `e59362e7` `[v0.20.2] [Fix] Paint index folder root gutter`
+- `cca26574` `[v0.20.3] [Fix] Show workflow move button labels`
+- `ec782d3d` `[v0.20.3] [Fix] Paint color picker root surfaces`
+- `8c025fb4` `[v0.20.3] [Fix] Paint image analyzer root surface`
+- `4d411ce0` `[v0.20.3] [Fix] Paint image combiner root surface`
+- `87946d13` `[v0.20.3] [Fix] Paint image splitter root surface`
+- `550ab5f8` `[v0.20.3] [Fix] Paint image thumbnailer root surface`
+- `17ffcb04` `[v0.20.3] [Fix] Keep index folder controls visible`
+- `2160e463` `[v0.20.3] [Fix] Use accent buttons in image combiner`
+- `7db2f3ed` `[v0.20.3] [Fix] Accent scrollbar thumbs app wide`
+- `c20f703e` `[v0.20.3] [Fix] Widen image combiner options layout`
+- `dc6bb5ba` `[v0.20.3] [Fix] Place color picker swatch tooltips above chips`
+- `7a314245` `[v0.20.3] [Fix] Paint hash check window surface`
+- `d2e82af6` `[v0.20.3] [Fix] Use accent buttons in image splitter`
+- `77eaede2` `[v0.20.3] [Fix] Use accent buttons in video converter`
+- `553bc915` `[v0.20.3] [Fix] Use accent buttons in video thumbnailer`
+- `b2bed6c1` `[v0.20.3] [Fix] Use accent buttons in image thumbnailer`
+- `2b661408` `[v0.20.3] [Fix] Use accent buttons in upload content`
+- `7cbeef73` `[v0.20.3] [Fix] Use accent buttons in color picker`
+- `6895b18e` `[v0.20.3] [Refactor] Make accent the default button style`
+- `d77b4a4f` `[v0.20.3] [Fix] Restore neutral scrollbars and disable auto-hide`
+- `9d4e09be` `[v0.20.2] [UI] Update editor integration and tools navigation`
+- `43b7c8f9` `[v0.20.2] [Cleanup] Remove stale editor toolbar references`
+- `80677704` `Update run-debug-app.sh`
+- `8254e13c` `[v0.20.3] [Refactor] Centralize desktop theme styles`
+- `4b88f19c` `[v0.20.3] [Fix] Paint video tool window surfaces`
+- `b10a5338` `[v0.20.3] [UI] Show File Save and Save As only when image loaded in editor`
+- `119d6324` `[v0.20.3] [Submodule] Update ShareX.ImageEditor: disable Copy when no image`
+- `1cca79ec` `[v0.20.3] [UI] Sort View Zoom menu alphabetically; zoom enabled only with image`
+- `0e1e8d3a` `[v0.20.3] [Docs] Add 2026-03-15 theme and tool-window polish blog draft.`
+- `7a1a8e58` `[v0.20.4] [CI] Release v0.20.4`
+- `e8689dc8` `[v0.20.3] [UI] File Save/Save As disabled when no image instead of hidden`
+- `d443d776` `[v0.20.3] [Docs] Add blog scheduling (Cursor Automations, cron, run-daily-draft)`
+- `968c236c` `[v0.20.3] [Fix] Harden Linux selector preference handling`
+- `181f8230` `[v0.20.3] [Fix] Stage workflow editor changes until save`
+- `3196b458` `[v0.20.4] [Refactor] Rename agent skills to improve discoverability`
+- `e55618f0` `[v0.20.3] [Fix] Resync drag modifiers during region capture`
+- `b69fe286` `[v0.20.3] [Fix] Drain portal hotkey rebinds before dispose`
+- `5e8aaccd` `[v0.20.3] [Fix] Surface Linux selector runtime decisions`
+- `503e4438` `Create XIP0052-agentic-refactoring.md`
+- `e76059b8` `[v0.20.4] [Docs] Add XIP0052 for agentic refactoring`
 
 ShareX.ImageEditor:
 
-- `314898dd` `[UI] Enable zoom commands only when image loaded`
-- `81586e4a` `[UI] Disable Edit Copy to Clipboard when no image loaded in editor`
-- `fc04e7d1` `[Refactor] Add semantic status palette tokens`
-- `420bf69e` `[Cleanup] Remove unused capture toolbar option`
-- `f6321781` `[UI] Add task mode button visibility option`
-- `04c28b14` `[Fix] Use matching move-down host icon`
-- `b9761db8` `[Fix] Use visible move-up host icon`
+- `b9761db` `[Fix] Use visible move-up host icon`
+- `04c28b1` `[Fix] Use matching move-down host icon`
+- `f632178` `[UI] Add task mode button visibility option`
+- `420bf69` `[Cleanup] Remove unused capture toolbar option`
+- `fc04e7d` `[Refactor] Add semantic status palette tokens`
+- `81586e4` `[UI] Disable Edit Copy to Clipboard when no image loaded in editor`
+- `314898d` `[UI] Enable zoom commands only when image loaded`
+- `a617494` `[UI] Disable Save/Save As when no image (avoid orphan separator)`
 
 ## Notes
 
-- Theme centralization and the broad tool-window surface fixes reduce drift between tools and improve consistency on both light and dark themes.
-- XerahS.Editor was not checked for this day (not present in this workspace); only XerahS and ShareX.ImageEditor were used as sources.
+- XerahS.Editor was checked for this UTC+8 day and had no commits.
+- March 15 spans both `v0.20.3` feature/fix work and the later `v0.20.4` release work, so the day intentionally mixes both version prefixes in the reviewed commit list.
+- The `XIP0052` proposal file landed in `503e4438`, while the follow-up docs commit `e76059b8` carries the matching subject but only changes `build_errors.txt`; if that proposal needs a cleaner publication trail, that docs history should be tidied later.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Update the March 14 and March 15, 2026 blog posts to reflect complete and accurate daily development activity.

The previous drafts were based on earlier snapshots of the day's work and missed later commits across the main repository and its submodules. This PR expands the March 14 post to include late-day host/theme/task-mode work and updates the March 15 post with Linux selector fixes, release/docs work, and a correction to editor command-state behavior.

<div><a href="https://cursor.com/agents/bc-abbea484-29d7-409b-bcef-e18e56db21e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abbea484-29d7-409b-bcef-e18e56db21e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->