### PR TITLE
Daily blog post content

### DIFF
--- a/docs/blog/2026/2026-03/blog-20260315.md
+++ b/docs/blog/2026/2026-03/blog-20260315.md
@@ -6,74 +6,96 @@ Status: Draft
 
 ## Summary
 
-March 15 focused on theme consistency and tool-window reliability across XerahS and ShareX.ImageEditor. XerahS centralized desktop theme styles, applied accent buttons and scrollbars app-wide, and fixed root-surface painting for every tool window (image combiner, splitter, thumbnailer, video converter, color picker, hash check, index folder, and video tool) so they respect the active theme. ShareX.ImageEditor added a task-mode button visibility option, enabled zoom and Copy only when an image is loaded, introduced semantic status palette tokens, and aligned move-up/move-down icons with the host. Editor integration and tools navigation were updated in XerahS and the ImageEditor submodule was refreshed to match.
+March 15 started as a broad UI and theming cleanup across XerahS and ShareX.ImageEditor, with tool windows repainted to respect their themed root surfaces, accent behavior normalized across common actions, and editor command visibility tightened around whether an image is actually loaded. As the day continued, the work expanded into Linux capture reliability and workflow editing correctness: selector preference handling was hardened, drag modifiers and portal hotkey teardown were made more robust, and workflow edits were staged until save instead of mutating live settings immediately. The day also introduced contributor-facing infrastructure work, including blog scheduling docs, the v0.20.4 release metadata, and the opening XIP0052 refactor stream for dependency injection, task-pipeline extraction, and cleaner MVVM dialog boundaries.
 
 ## Features
 
-- Sorted the View Zoom menu alphabetically and enabled zoom commands only when an image is loaded in the editor (XerahS and ShareX.ImageEditor).
-- Show File Save and Save As only when an image is loaded in the editor.
-- ShareX.ImageEditor: added task mode button visibility option; disabled Edit Copy to Clipboard when no image is loaded; added semantic status palette tokens for consistent theming.
+- XerahS and ShareX.ImageEditor now keep zoom, copy, save, and save-as commands aligned with editor state so those actions only light up when an image is loaded, while the View Zoom menu is now alphabetized.
+- ShareX.ImageEditor added a task mode button visibility option and semantic status palette tokens, giving hosts more control over editor chrome and more consistent status-themed styling.
+- Linux selector diagnostics now surface the most recent runtime selector decision, and the workflow editor now behaves like a proper draft editor by keeping changes staged until Save or OK.
 
 ## Fixes
 
-- Painted tool window root surfaces and gutters correctly so theme backgrounds apply: video tool, image thumbnailer, splitter, combiner, analyzer, color picker, hash check window, and index folder surfaces (XerahS).
-- Applied accent button style app-wide: color picker, upload content, image and video thumbnailer, video converter, image splitter, image combiner; made accent the default button style; restored neutral scrollbars and disabled auto-hide; accent scrollbar thumbs app-wide.
-- Updated ShareX.ImageEditor move-up and move-down icons to match the host; XerahS submodule updated to use the new icons.
-- Placed color picker swatch tooltips above chips; widened image combiner options layout; showed workflow move button labels; kept index folder controls visible.
+- XerahS repainted themed root surfaces and gutters across the video tool, image thumbnailer, splitter, combiner, analyzer, color picker, hash check window, and index folder so dark and light themes no longer fall through to incorrect host backgrounds.
+- Accent styling was normalized across color picker, upload content, image and video thumbnailers, video converter, image splitter, and image combiner. The app also restored neutral scrollbars, disabled scrollbar auto-hide, and kept accent styling focused on the intended thumb and action surfaces.
+- Color picker tooltips, image combiner spacing, workflow move button labels, and index folder control visibility were all corrected to keep secondary tools readable and usable.
+- Linux capture handling was hardened in several directions at once: selector preference handling became stricter, drag modifier state now resyncs while selecting, portal hotkey rebind work drains before disposal, and new tests cover selector diagnostics and staged workflow editing behavior.
+- ShareX.ImageEditor aligned move-up and move-down host icons, disabled Copy when no image is loaded, and moved save commands from hidden to disabled so the editor command surface stays stable even when no document is open.
 
 ## Build and Tooling
 
-- Updated `run-debug-app.sh` for local debugging.
-- XerahS: removed stale editor toolbar references; updated editor integration and tools navigation. ShareX.ImageEditor: removed unused capture toolbar option.
+- Updated `run-debug-app.sh` for local debugging and documented automated blog scheduling through Cursor Automations, cron, and the `run-daily-draft` wrapper.
+- Published the v0.20.4 release metadata and changelog updates.
+- Started the XIP0052 refactor stream with a design document, renamed agent skills for easier discovery, migrated bootstrap wiring to `Microsoft.Extensions.DependencyInjection`, extracted the `WorkerTask` pipeline and Linux capture option resolution into focused classes, and introduced dialog-service abstractions to reduce direct UI coupling in view models.
 
 ## Commits Reviewed
 
 XerahS:
 
-- `1cca79ec` `[v0.20.3] [UI] Sort View Zoom menu alphabetically; zoom enabled only with image`
-- `119d6324` `[v0.20.3] [Submodule] Update ShareX.ImageEditor: disable Copy when no image`
-- `b10a5338` `[v0.20.3] [UI] Show File Save and Save As only when image loaded in editor`
-- `4b88f19c` `[v0.20.3] [Fix] Paint video tool window surfaces`
-- `8254e13c` `[v0.20.3] [Refactor] Centralize desktop theme styles`
-- `80677704` `Update run-debug-app.sh`
-- `43b7c8f9` `[v0.20.2] [Cleanup] Remove stale editor toolbar references`
-- `9d4e09be` `[v0.20.2] [UI] Update editor integration and tools navigation`
-- `d77b4a4f` `[v0.20.3] [Fix] Restore neutral scrollbars and disable auto-hide`
-- `6895b18e` `[v0.20.3] [Refactor] Make accent the default button style`
-- `7cbeef73` `[v0.20.3] [Fix] Use accent buttons in color picker`
-- `24093641` `[v0.20.3] [Fix] Update ShareX.ImageEditor move-down icon`
-- `2b661408` `[v0.20.3] [Fix] Use accent buttons in upload content`
-- `b2bed6c1` `[v0.20.3] [Fix] Use accent buttons in image thumbnailer`
-- `553bc915` `[v0.20.3] [Fix] Use accent buttons in video thumbnailer`
-- `77eaede2` `[v0.20.3] [Fix] Use accent buttons in video converter`
-- `d2e82af6` `[v0.20.3] [Fix] Use accent buttons in image splitter`
-- `7a314245` `[v0.20.3] [Fix] Paint hash check window surface`
-- `dc6bb5ba` `[v0.20.3] [Fix] Place color picker swatch tooltips above chips`
-- `c20f703e` `[v0.20.3] [Fix] Widen image combiner options layout`
-- `7db2f3ed` `[v0.20.3] [Fix] Accent scrollbar thumbs app wide`
-- `857b192d` `[v0.20.3] [Fix] Update ShareX.ImageEditor move-up icon`
-- `2160e463` `[v0.20.3] [Fix] Use accent buttons in image combiner`
-- `17ffcb04` `[v0.20.3] [Fix] Keep index folder controls visible`
-- `550ab5f8` `[v0.20.3] [Fix] Paint image thumbnailer root surface`
-- `87946d13` `[v0.20.3] [Fix] Paint image splitter root surface`
-- `4d411ce0` `[v0.20.3] [Fix] Paint image combiner root surface`
-- `8c025fb4` `[v0.20.3] [Fix] Paint image analyzer root surface`
-- `ec782d3d` `[v0.20.3] [Fix] Paint color picker root surfaces`
-- `cca26574` `[v0.20.3] [Fix] Show workflow move button labels`
-- `e59362e7` `[v0.20.2] [Fix] Paint index folder root gutter`
 - `5a7ea131` `[v0.20.2] [Fix] Paint index folder surfaces explicitly`
+- `e59362e7` `[v0.20.2] [Fix] Paint index folder root gutter`
+- `cca26574` `[v0.20.3] [Fix] Show workflow move button labels`
+- `ec782d3d` `[v0.20.3] [Fix] Paint color picker root surfaces`
+- `8c025fb4` `[v0.20.3] [Fix] Paint image analyzer root surface`
+- `4d411ce0` `[v0.20.3] [Fix] Paint image combiner root surface`
+- `87946d13` `[v0.20.3] [Fix] Paint image splitter root surface`
+- `550ab5f8` `[v0.20.3] [Fix] Paint image thumbnailer root surface`
+- `17ffcb04` `[v0.20.3] [Fix] Keep index folder controls visible`
+- `2160e463` `[v0.20.3] [Fix] Use accent buttons in image combiner`
+- `857b192d` `[v0.20.3] [Fix] Update ShareX.ImageEditor move-up icon`
+- `7db2f3ed` `[v0.20.3] [Fix] Accent scrollbar thumbs app wide`
+- `c20f703e` `[v0.20.3] [Fix] Widen image combiner options layout`
+- `dc6bb5ba` `[v0.20.3] [Fix] Place color picker swatch tooltips above chips`
+- `7a314245` `[v0.20.3] [Fix] Paint hash check window surface`
+- `d2e82af6` `[v0.20.3] [Fix] Use accent buttons in image splitter`
+- `77eaede2` `[v0.20.3] [Fix] Use accent buttons in video converter`
+- `553bc915` `[v0.20.3] [Fix] Use accent buttons in video thumbnailer`
+- `b2bed6c1` `[v0.20.3] [Fix] Use accent buttons in image thumbnailer`
+- `2b661408` `[v0.20.3] [Fix] Use accent buttons in upload content`
+- `24093641` `[v0.20.3] [Fix] Update ShareX.ImageEditor move-down icon`
+- `7cbeef73` `[v0.20.3] [Fix] Use accent buttons in color picker`
+- `6895b18e` `[v0.20.3] [Refactor] Make accent the default button style`
+- `d77b4a4f` `[v0.20.3] [Fix] Restore neutral scrollbars and disable auto-hide`
+- `9d4e09be` `[v0.20.2] [UI] Update editor integration and tools navigation`
+- `43b7c8f9` `[v0.20.2] [Cleanup] Remove stale editor toolbar references`
+- `80677704` `Update run-debug-app.sh`
+- `8254e13c` `[v0.20.3] [Refactor] Centralize desktop theme styles`
+- `4b88f19c` `[v0.20.3] [Fix] Paint video tool window surfaces`
+- `b10a5338` `[v0.20.3] [UI] Show File Save and Save As only when image loaded in editor`
+- `119d6324` `[v0.20.3] [Submodule] Update ShareX.ImageEditor: disable Copy when no image`
+- `1cca79ec` `[v0.20.3] [UI] Sort View Zoom menu alphabetically; zoom enabled only with image`
+- `0e1e8d3a` `[v0.20.3] [Docs] Add 2026-03-15 theme and tool-window polish blog draft.`
+- `7a1a8e58` `[v0.20.4] [CI] Release v0.20.4`
+- `e8689dc8` `[v0.20.3] [UI] File Save/Save As disabled when no image instead of hidden`
+- `d443d776` `[v0.20.3] [Docs] Add blog scheduling (Cursor Automations, cron, run-daily-draft)`
+- `968c236c` `[v0.20.3] [Fix] Harden Linux selector preference handling`
+- `181f8230` `[v0.20.3] [Fix] Stage workflow editor changes until save`
+- `3196b458` `[v0.20.4] [Refactor] Rename agent skills to improve discoverability`
+- `e55618f0` `[v0.20.3] [Fix] Resync drag modifiers during region capture`
+- `b69fe286` `[v0.20.3] [Fix] Drain portal hotkey rebinds before dispose`
+- `5e8aaccd` `[v0.20.3] [Fix] Surface Linux selector runtime decisions`
+- `503e4438` `Create XIP0052-agentic-refactoring.md`
+- `e76059b8` `[v0.20.4] [Docs] Add XIP0052 for agentic refactoring`
+- `a1c37be1` `XIP0052: Migrate to Microsoft.Extensions.DependencyInjection`
+- `ef40ed9a` `Refactor: extract pipeline from WorkerTask and Linux options from ScreenCaptureService`
+- `7b0e9930` `Phase 3: Refactor ViewModels to abstract dialogs and ensure MVVM separation`
 
 ShareX.ImageEditor:
 
-- `314898dd` `[UI] Enable zoom commands only when image loaded`
-- `81586e4a` `[UI] Disable Edit Copy to Clipboard when no image loaded in editor`
-- `fc04e7d1` `[Refactor] Add semantic status palette tokens`
-- `420bf69e` `[Cleanup] Remove unused capture toolbar option`
-- `f6321781` `[UI] Add task mode button visibility option`
-- `04c28b14` `[Fix] Use matching move-down host icon`
 - `b9761db8` `[Fix] Use visible move-up host icon`
+- `04c28b14` `[Fix] Use matching move-down host icon`
+- `f6321781` `[UI] Add task mode button visibility option`
+- `420bf69e` `[Cleanup] Remove unused capture toolbar option`
+- `fc04e7d1` `[Refactor] Add semantic status palette tokens`
+- `81586e4a` `[UI] Disable Edit Copy to Clipboard when no image loaded in editor`
+- `314898dd` `[UI] Enable zoom commands only when image loaded`
+- `a617494c` `[UI] Disable Save/Save As when no image (avoid orphan separator)`
+
+XerahS.Editor:
+
+- No commits matched this UTC+8 day.
 
 ## Notes
 
-- Theme centralization and the broad tool-window surface fixes reduce drift between tools and improve consistency on both light and dark themes.
-- XerahS.Editor was not checked for this day (not present in this workspace); only XerahS and ShareX.ImageEditor were used as sources.
+- March 15 covered both visible UI polish and deeper architecture work, so the blog draft intentionally combines end-user improvements with contributor-facing refactors and tooling updates.
+- XerahS.Editor was checked via remote commit history for this UTC+8 day and had no matching commits.

--- a/docs/blog/2026/2026-03/blog-20260316.md
+++ b/docs/blog/2026/2026-03/blog-20260316.md
@@ -6,25 +6,60 @@ Status: Draft
 
 ## Summary
 
-TBD
+March 16 combined a large architectural landing from XIP0052 with a second wave of user-facing fixes across capture flows, QR tooling, Linux selector UX, and platform integration settings. XerahS completed its move toward `Microsoft.Extensions.DependencyInjection` in the UI composition root, split `ScreenCaptureService` into smaller capture and selector services, and replaced more direct Avalonia lifecycle and dialog dependencies with abstractions that fit the MVVM boundary better. Alongside that refactor, the app refreshed After Capture and QR layouts, restored accent styling where it had drifted, aligned the embedded editor with ShareX.ImageEditor's renamed exit-confirmation option, wired startup and shell integration toggles to real Windows, Linux, and macOS services, and switched app-wide accent tracking to platform `SystemAccentColor` resources.
 
 ## Features
 
-- TBD
+- Integration settings now apply to real platform services instead of no-op placeholders: Windows gained startup, shell, Send To, and `.xsdp` association support; Linux gained user-level shell integration handlers for plugin associations, file-manager scripts, and Send To entries; macOS gained LaunchAgent startup support and explicit unsupported-state reporting for Finder shell features.
+- Wayland sessions with screenshot portal support can now expose the XerahS overlay selector while keeping the capture path on the portal flow, and Linux current-session diagnostics now label session type, desktop, and compositor values more clearly.
+- XerahS now tracks the host operating system's accent color through `SystemAccentColor` resources so accent-driven controls stay aligned with platform color preferences across the app.
 
 ## Fixes
 
-- TBD
+- Completed the remaining XIP0052 implementation work by moving the UI composition root onto DI, extracting `CaptureImageCompositor` and `LinuxRegionSelectorResolver`, adding lifecycle and dialog-service abstractions, and fixing pre-existing build breaks in several view models while tightening MVVM separation.
+- Refreshed the After Capture and QR tool window layouts, removed lingering `NoAccent` button opt-outs, restored QR dialog accent buttons, and corrected the After Capture border thickness resource so the updated layouts render with the right theme resources.
+- Aligned XerahS task-mode editor initialization with ShareX.ImageEditor's `ShowExitConfirmation` rename after the submodule update, keeping close confirmation behavior consistent with the editor host contract.
+- Removed duplicate or orphaned source files left over from earlier merges, including `IndexerHtmlAsync.cs` and `CustomUploaderConfigView.axaml.cs`, to keep the tree clean and prevent duplicate definitions.
 
 ## Build and Tooling
 
-- TBD
+- Landed the large XIP0052 refactor commit that finished the dependency-injection migration path, decomposed `ScreenCaptureService`, and registered the new lifecycle and dialog abstractions in the app's service graph.
+- Updated the `design-ui-window` skill while refining QR dialog accent behavior so the design guidance stays aligned with the current theming direction.
+- Reviewed and integrated ShareX.ImageEditor commit `560d84ce`, which renamed `ExitConfirmation` to `ShowExitConfirmation` in the editor host options surface.
 
 ## Commits Reviewed
 
-- TBD
+XerahS:
+
+- `dccf0292` `XIP0052: Complete agentic refactoring — DI, MVVM, monolith decomposition`
+- `a198d4bd` `[v0.20.3] [Docs] Update design UI window skill`
+- `73e1492e` `[v0.20.3] [Fix] Refresh capture and QR tool window layouts`
+- `67946a81` `[v0.20.3] [Fix] Restore QR dialog accent buttons`
+- `0adcf003` `Update ShareX.ImageEditor`
+- `215e6ba7` `[v0.20.3] [Fix] Align ImageEditor exit confirmation option`
+- `c346fb3f` `[v0.20.3] [Fix] Remove remaining NoAccent button opt-outs`
+- `8dff079d` `[v0.20.3] [Fix] Ensure Automatic and XerahS overlay in Linux region selector dropdown`
+- `bd0c5417` `[v0.20.4] [Fix] Correct AfterCapture border thickness resource`
+- `6f96bbac` `[v0.20.3] [Fix] Enable Wayland overlay selector with portal capture`
+- `9ada3db5` `[v0.20.3] [UX] Clarify Linux current-session diagnostics labels`
+- `498ce04d` `[Fix] Wire integration toggles to real platform services.`
+- `2b724b9c` `[Fix] Implement Windows startup and shell integration entries.`
+- `fc366b80` `[Fix] Add Linux shell integration handlers for system options.`
+- `ffd1b400` `[Fix] Add macOS startup integration and explicit shell support reporting.`
+- `0b6dee79` `[Fix] Remove duplicate IndexerHtmlAsync.cs (replaced by IndexerSyncAdapter.cs in merge)`
+- `996790db` `[Fix] Remove orphaned CustomUploaderConfigView.axaml.cs (AXAML deleted, duplicate class)`
+- `60837e44` `[UI] Track OS system accent colour app-wide via SystemAccentColor`
+
+ShareX.ImageEditor:
+
+- `560d84ce` `Rename ExitConfirmation to ShowExitConfirmation`
+
+XerahS.Editor:
+
+- No commits matched this UTC+8 day.
 
 ## Notes
 
-- TBD
+- This draft reflects commits available when the automation ran on the morning of 2026-03-16 UTC+8, so it may need another pass later in the day if more work lands.
+- XerahS.Editor was checked via remote commit history for this UTC+8 day and had no matching commits.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Update March 15 and March 16 daily blog posts to reflect actual git history and replace a skeleton draft.

The existing March 15 draft was incomplete, missing later work like Linux selector fixes, workflow-editor staging, the v0.20.4 release, and XIP0052 refactoring. The March 16 post was a skeleton. This PR updates both posts to provide accurate, commit-grounded daily summaries.

<div><a href="https://cursor.com/agents/bc-ed46b68e-15c7-4b5c-bc2b-992afe515023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed46b68e-15c7-4b5c-bc2b-992afe515023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->