### PR TITLE
Codex/xip0056 custom uploader ux

### DIFF
--- a/developers/lessons-learnt/general.md
+++ b/developers/lessons-learnt/general.md
@@ -41,6 +41,7 @@ Promote only repository-wide policy changes to `AGENTS.md`.
 - Never duplicate semantic control classes like `section-header`, `caption`, `readonly`, or status colors inside individual views; always define them once in `src/desktop/app/XerahS.UI/Themes/ThemeResources.axaml` and back them with palette tokens in `ShareX.ImageEditor/src/ShareX.ImageEditor/Presentation/Theming/ImageEditorTheme.axaml` because local copies stop whole-app theme changes from propagating consistently.
 - Never store a border thickness token as `x:Double` when it will feed `BorderThickness`; always declare it as `Thickness` because Avalonia style setters will reject a numeric resource value for a `Thickness` property at runtime even when inline `BorderThickness="1"` looks valid.
 - Never bind workflow-edit dialogs directly to the live `WorkflowSettings` instance; always edit a working copy, apply it only on `OK`, and show the real job separately from the custom description because otherwise `Cancel` is not real and workflow names can silently drift away from the task they actually execute.
+- Never use decorative Unicode glyphs in button labels, status text, or debug prefixes unless the file already intentionally depends on them and the round-trip encoding has been verified; always prefer ASCII-safe labels such as `...`, `[OK]`, `[ERROR]`, and `[FAIL]` because editor and PowerShell write paths can silently turn those glyphs into mojibake in source and UI.
 
 ### ContextMenu vs. ContextFlyout
 

--- a/src/desktop/app/XerahS.UI/ViewModels/CustomUploaderEditorViewModel.cs
+++ b/src/desktop/app/XerahS.UI/ViewModels/CustomUploaderEditorViewModel.cs
@@ -33,6 +33,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using XerahS.Uploaders;
 using XerahS.Uploaders.CustomUploader;
@@ -446,14 +447,51 @@ public partial class CustomUploaderEditorViewModel : ViewModelBase, INotifyDataE
 
         try
         {
-            await Task.Delay(500); // Allow UI to update
-
+            await Task.Yield();
             var item = ToItem();
-            var executor = new XerahS.Uploaders.CustomUploader.CustomUploaderExecutor(item);
+            var previewInput = new CustomUploaderInput("example-upload.png", "sample-upload-content");
+            var requestUrl = item.GetRequestURL(previewInput);
+            var parameters = item.GetParameters(previewInput);
+            var headers = item.GetHeaders(previewInput);
+            var arguments = item.GetArguments(previewInput);
+            var bodyPreview = DescribeBodyPreview(item, previewInput, arguments);
 
-            // Create a simple test - just verify the URL is reachable
-            // A full test would require actual file upload
-            SetStatus("Uploader configuration is valid. Save and test with an actual upload.", false);
+            var builder = new StringBuilder();
+            builder.AppendLine("Validation passed. Preview only - no network request was sent.");
+            builder.AppendLine();
+            builder.AppendLine($"Resolved request URL: {requestUrl}");
+            builder.AppendLine($"HTTP method: {item.RequestMethod}");
+            builder.AppendLine($"Body preview: {bodyPreview}");
+
+            if (parameters.Count > 0)
+            {
+                builder.AppendLine();
+                builder.AppendLine("Resolved URL parameters:");
+                builder.AppendLine(FormatKeyValuePairs(parameters));
+            }
+
+            if (headers.Count > 0)
+            {
+                builder.AppendLine();
+                builder.AppendLine("Resolved headers:");
+                builder.AppendLine(FormatHeaders(headers));
+            }
+
+            if (arguments.Count > 0)
+            {
+                builder.AppendLine();
+                builder.AppendLine("Resolved form arguments:");
+                builder.AppendLine(FormatKeyValuePairs(arguments));
+            }
+
+            builder.AppendLine();
+            builder.AppendLine("Response rules:");
+            builder.AppendLine(DescribeResponseRule("URL", UrlPattern));
+            builder.AppendLine(DescribeResponseRule("Thumbnail URL", ThumbnailUrlPattern));
+            builder.AppendLine(DescribeResponseRule("Deletion URL", DeletionUrlPattern));
+            builder.AppendLine(DescribeResponseRule("Error message", ErrorMessagePattern));
+
+            SetStatus(builder.ToString().TrimEnd(), false);
         }
         catch (Exception ex)
         {
@@ -622,6 +660,56 @@ public partial class CustomUploaderEditorViewModel : ViewModelBase, INotifyDataE
     {
         StatusMessage = message;
         IsStatusError = isError;
+    }
+
+    private static string DescribeBodyPreview(
+        CustomUploaderItem item,
+        CustomUploaderInput previewInput,
+        IReadOnlyDictionary<string, string> arguments)
+    {
+        return item.Body switch
+        {
+            CustomUploaderBody.MultipartFormData => $"multipart/form-data using file field '{item.GetFileFormName()}'",
+            CustomUploaderBody.FormURLEncoded => arguments.Count > 0
+                ? $"application/x-www-form-urlencoded with {arguments.Count} field(s)"
+                : "application/x-www-form-urlencoded with no extra fields",
+            CustomUploaderBody.JSON => $"JSON payload: {item.GetData(previewInput)}",
+            CustomUploaderBody.XML => $"XML payload: {item.GetData(previewInput)}",
+            CustomUploaderBody.Binary => "binary file upload",
+            _ => "no request body"
+        };
+    }
+
+    private static string DescribeResponseRule(string label, string pattern)
+    {
+        if (string.IsNullOrWhiteSpace(pattern))
+        {
+            return $"- {label}: not configured";
+        }
+
+        string ruleType = pattern.Contains("{json:", StringComparison.OrdinalIgnoreCase)
+            ? "JSON extraction"
+            : pattern.Contains("{regex:", StringComparison.OrdinalIgnoreCase)
+                ? "regex extraction"
+                : pattern.Contains("{response}", StringComparison.OrdinalIgnoreCase)
+                    ? "raw response"
+                    : "custom pattern";
+
+        return $"- {label}: {ruleType} -> {pattern}";
+    }
+
+    private static string FormatHeaders(System.Collections.Specialized.NameValueCollection headers)
+    {
+        var pairs = headers.AllKeys
+            .Where(key => !string.IsNullOrWhiteSpace(key))
+            .Select(key => new KeyValuePair<string, string>(key!, headers[key] ?? string.Empty));
+
+        return FormatKeyValuePairs(pairs);
+    }
+
+    private static string FormatKeyValuePairs(IEnumerable<KeyValuePair<string, string>> pairs)
+    {
+        return string.Join(Environment.NewLine, pairs.Select(pair => $"- {pair.Key}: {pair.Value}"));
     }
 
     #endregion

--- a/src/desktop/app/XerahS.UI/ViewModels/DestinationSettingsViewModel.cs
+++ b/src/desktop/app/XerahS.UI/ViewModels/DestinationSettingsViewModel.cs
@@ -186,18 +186,14 @@ public partial class DestinationSettingsViewModel : ViewModelBase
 
             if (customUploaderExport.ExportedCount > 0 || customUploaderExport.SkippedCount > 0)
             {
-                ProviderCatalog.LoadCustomUploaders(customUploaderExport.PluginsPath);
-
-                // Auto-create instances for newly exported custom uploaders
                 foreach (var filePath in customUploaderExport.ExportedFilePaths)
                 {
-                    AutoCreateCustomUploaderInstances(filePath, customUploaderExport);
+                    var instanceResult = EnsureCustomUploaderInstances(filePath);
+                    customUploaderExport.InstancesCreated += instanceResult.CreatedInstances.Count;
+                    customUploaderExport.InstancesSkipped += instanceResult.SkippedCategories.Count;
                 }
 
-                foreach (var category in Categories)
-                {
-                    category.LoadInstances();
-                }
+                RefreshCategories(Categories.Select(category => category.Category));
             }
 
             // Migrate built-in provider settings (S3, FTP, Pastebin, Imgur)
@@ -281,17 +277,11 @@ public partial class DestinationSettingsViewModel : ViewModelBase
 
                 if (CustomUploaderRepository.SaveToFile(item, filePath))
                 {
-                    // Reload custom uploaders to include the new one
-                    ProviderCatalog.LoadCustomUploaders(pluginsPath);
-
-                    // Refresh all categories to show the new uploader
-                    foreach (var category in Categories)
-                    {
-                        category.LoadInstances();
-                    }
+                    var instanceResult = EnsureCustomUploaderInstances(filePath);
+                    RefreshCategories(instanceResult.AffectedCategories);
 
                     await ShowMessageDialogAsync("Custom Uploader Created",
-                        $"Custom uploader '{item.Name}' has been saved and is now available in the catalog.");
+                        BuildCustomUploaderCreatedMessage(item.Name, instanceResult));
                 }
                 else
                 {
@@ -307,46 +297,103 @@ public partial class DestinationSettingsViewModel : ViewModelBase
         }
     }
 
-    private static void AutoCreateCustomUploaderInstances(string filePath, CustomUploaderExportResult exportResult)
+    private CustomUploaderInstanceCreationResult EnsureCustomUploaderInstances(string filePath)
     {
-        string baseName = Path.GetFileNameWithoutExtension(filePath);
-        string slug = System.Text.RegularExpressions.Regex.Replace(
-            baseName.ToLowerInvariant(), @"[^a-z0-9]+", "_").Trim('_');
-        if (string.IsNullOrEmpty(slug)) slug = "unknown";
-        string providerId = $"custom_{slug}";
-
-        var provider = ProviderCatalog.GetProvider(providerId);
-        if (provider == null) return;
-
-        foreach (var category in provider.SupportedCategories)
+        if (!ProviderCatalog.ReloadCustomUploader(filePath))
         {
-            bool alreadyExists = InstanceManager.Instance
-                .GetInstancesByCategory(category)
-                .Any(i => string.Equals(i.ProviderId, providerId, StringComparison.OrdinalIgnoreCase));
-
-            if (alreadyExists)
-            {
-                exportResult.InstancesSkipped++;
-                continue;
-            }
-
-            try
-            {
-                InstanceManager.Instance.AddInstance(new UploaderInstance
-                {
-                    ProviderId = providerId,
-                    Category = category,
-                    DisplayName = provider.Name,
-                    SettingsJson = provider.GetDefaultSettings(category),
-                    FileTypeRouting = new FileTypeScope { AllFileTypes = true }
-                });
-                exportResult.InstancesCreated++;
-            }
-            catch (Exception ex)
-            {
-                Common.DebugHelper.WriteException(ex, $"[DestinationSettings] Failed to auto-create instance for {providerId}/{category}");
-            }
+            ProviderCatalog.LoadCustomUploaders(Path.GetDirectoryName(filePath) ?? PathsManager.PluginsFolder);
         }
+
+        var provider = CustomUploaderDefinitionBindingService.GetProviderByFilePath(filePath);
+        if (provider == null)
+        {
+            Common.DebugHelper.WriteLine($"[DestinationSettings] Failed to resolve custom uploader provider for: {filePath}");
+            return new CustomUploaderInstanceCreationResult();
+        }
+
+        var result = CustomUploaderDefinitionBindingService.CreateMissingInstances(provider);
+
+        try
+        {
+            var boundInstanceIds = CustomUploaderDefinitionBindingService.GetBoundInstanceIds(provider.ProviderId);
+            CustomUploaderDefinitionBindingService.SaveDefinition(provider.Item, provider.FilePath, boundInstanceIds);
+            ProviderCatalog.ReloadCustomUploader(provider.FilePath);
+        }
+        catch (Exception ex)
+        {
+            Common.DebugHelper.WriteException(ex, $"[DestinationSettings] Failed to update custom uploader metadata for {provider.ProviderId}");
+        }
+
+        return result;
+    }
+
+    private void RefreshCategories(IEnumerable<UploaderCategory> categories)
+    {
+        var categorySet = categories.Distinct().ToHashSet();
+
+        if (categorySet.Count == 0)
+        {
+            foreach (var category in Categories)
+            {
+                category.LoadInstances();
+            }
+
+            return;
+        }
+
+        foreach (var category in Categories.Where(category => categorySet.Contains(category.Category)))
+        {
+            category.LoadInstances();
+        }
+    }
+
+    private static string BuildCustomUploaderCreatedMessage(string uploaderName, CustomUploaderInstanceCreationResult instanceResult)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine($"Custom uploader '{uploaderName}' has been saved to Plugins.");
+
+        if (instanceResult.CreatedInstances.Count > 0)
+        {
+            builder.AppendLine();
+            builder.AppendLine($"Created {instanceResult.CreatedInstances.Count} destination instance(s): {FormatCategoryList(instanceResult.CreatedInstances.Select(instance => instance.Category))}.");
+        }
+
+        if (instanceResult.SkippedCategories.Count > 0)
+        {
+            builder.AppendLine();
+            builder.AppendLine($"Existing instance bindings were reused for: {FormatCategoryList(instanceResult.SkippedCategories)}.");
+        }
+
+        if (instanceResult.CreatedInstances.Count == 0 && instanceResult.SkippedCategories.Count == 0)
+        {
+            builder.AppendLine();
+            builder.AppendLine("No destination categories were updated.");
+        }
+        else
+        {
+            builder.AppendLine();
+            builder.Append("The uploader is ready to use without Add from Catalog.");
+        }
+
+        return builder.ToString();
+    }
+
+    private static string FormatCategoryList(IEnumerable<UploaderCategory> categories)
+    {
+        var labels = categories
+            .Distinct()
+            .Select(category => category switch
+            {
+                UploaderCategory.Image => "Image Uploaders",
+                UploaderCategory.Text => "Text Uploaders",
+                UploaderCategory.File => "File Uploaders",
+                UploaderCategory.UrlShortener => "URL Shorteners",
+                UploaderCategory.UrlSharing => "URL Sharing",
+                _ => category.ToString()
+            })
+            .ToList();
+
+        return labels.Count > 0 ? string.Join(", ", labels) : "None";
     }
 
     private static string MakeSafeFileName(string name)
@@ -501,12 +548,13 @@ public partial class DestinationSettingsViewModel : ViewModelBase
             if (customUploaderExport.InstancesCreated > 0)
             {
                 builder.AppendLine();
-                builder.Append($"Auto-created {customUploaderExport.InstancesCreated} destination instance(s) — ready to use.");
+                builder.Append($"Auto-created {customUploaderExport.InstancesCreated} destination instance(s) - ready to use.");
             }
-            else if (customUploaderExport.ExportedCount > 0)
+
+            if (customUploaderExport.InstancesSkipped > 0)
             {
                 builder.AppendLine();
-                builder.Append("Next step: use \"Add from Catalog\" to create destination instances from imported custom uploaders.");
+                builder.Append($"Reused {customUploaderExport.InstancesSkipped} existing destination binding(s) without creating duplicates.");
             }
         }
 

--- a/src/desktop/app/XerahS.UI/ViewModels/DestinationSettingsViewModel.cs
+++ b/src/desktop/app/XerahS.UI/ViewModels/DestinationSettingsViewModel.cs
@@ -147,6 +147,11 @@ public partial class DestinationSettingsViewModel : ViewModelBase
         categoryVm?.LoadInstances();
     }
 
+    partial void OnSelectedCategoryChanged(CategoryViewModel? value)
+    {
+        value?.LoadInstances();
+    }
+
     [RelayCommand]
     private async Task OpenPluginInstaller()
     {

--- a/src/desktop/app/XerahS.UI/ViewModels/ProviderCatalogViewModel.cs
+++ b/src/desktop/app/XerahS.UI/ViewModels/ProviderCatalogViewModel.cs
@@ -25,6 +25,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using XerahS.Common;
+using XerahS.Uploaders.CustomUploader;
 using XerahS.Uploaders.PluginSystem;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -45,8 +46,15 @@ public partial class ProviderCatalogViewModel : ViewModelBase
     [ObservableProperty]
     private ProviderViewModel? _selectedProvider;
 
+    [ObservableProperty]
+    private bool _addToAllSupportedCategories = true;
+
     public Action<List<UploaderInstance>>? OnInstancesAdded { get; set; }
     public Action? OnCancelled { get; set; }
+
+    public bool CanAddToAllSupportedCategories => SelectedProvider?.SupportsMultipleCategories == true;
+
+    public string MultiCategorySelectionSummary => SelectedProvider?.SupportedCategoriesSummary ?? string.Empty;
 
     public ProviderCatalogViewModel(UploaderCategory category)
     {
@@ -69,6 +77,21 @@ public partial class ProviderCatalogViewModel : ViewModelBase
         }
 
         DebugHelper.WriteLine($"[ProviderCatalog] Total providers in AvailableProviders: {AvailableProviders.Count}");
+    }
+
+    partial void OnSelectedProviderChanged(ProviderViewModel? value)
+    {
+        if (value?.SupportsMultipleCategories != true)
+        {
+            AddToAllSupportedCategories = false;
+        }
+        else if (!AddToAllSupportedCategories)
+        {
+            AddToAllSupportedCategories = true;
+        }
+
+        OnPropertyChanged(nameof(CanAddToAllSupportedCategories));
+        OnPropertyChanged(nameof(MultiCategorySelectionSummary));
     }
 
 
@@ -104,17 +127,44 @@ public partial class ProviderCatalogViewModel : ViewModelBase
                 return;
             }
 
-            var instance = new UploaderInstance
-            {
-                ProviderId = provider.ProviderId,
-                Category = Category,
-                DisplayName = $"{provider.Name} ({Category})",
-                SettingsJson = provider.GetDefaultSettings(Category)
-            };
+            var targetCategories = GetTargetCategories(provider);
+            var createdInstances = new List<UploaderInstance>();
 
-            InstanceManager.Instance.AddInstance(instance);
+            foreach (var targetCategory in targetCategories)
+            {
+                bool alreadyExists = InstanceManager.Instance.GetInstancesByCategory(targetCategory)
+                    .Any(instance => string.Equals(instance.ProviderId, provider.ProviderId, StringComparison.OrdinalIgnoreCase));
+
+                if (alreadyExists)
+                {
+                    DebugHelper.WriteLine($"[ProviderCatalog] Skipping duplicate instance for {provider.ProviderId} in {targetCategory}");
+                    continue;
+                }
+
+                var instance = new UploaderInstance
+                {
+                    ProviderId = provider.ProviderId,
+                    Category = targetCategory,
+                    DisplayName = $"{provider.Name} ({targetCategory})",
+                    SettingsJson = provider.GetDefaultSettings(targetCategory)
+                };
+
+                InstanceManager.Instance.AddInstance(instance);
+                createdInstances.Add(instance);
+            }
+
+            if (provider is CustomUploaderProvider customUploaderProvider)
+            {
+                var boundInstanceIds = CustomUploaderDefinitionBindingService.GetBoundInstanceIds(customUploaderProvider.ProviderId);
+                CustomUploaderDefinitionBindingService.SaveDefinition(
+                    customUploaderProvider.Item,
+                    customUploaderProvider.FilePath,
+                    boundInstanceIds);
+                ProviderCatalog.ReloadCustomUploader(customUploaderProvider.FilePath);
+            }
+
             DebugHelper.WriteLine($"[ProviderCatalog] Instance added, invoking OnInstancesAdded callback...");
-            OnInstancesAdded?.Invoke(new List<UploaderInstance> { instance });
+            OnInstancesAdded?.Invoke(createdInstances);
             DebugHelper.WriteLine($"[ProviderCatalog] OnInstancesAdded callback invoked");
         }
         catch (Exception ex)
@@ -127,6 +177,13 @@ public partial class ProviderCatalogViewModel : ViewModelBase
     private void Cancel()
     {
         OnCancelled?.Invoke();
+    }
+
+    private UploaderCategory[] GetTargetCategories(IUploaderProvider provider)
+    {
+        return AddToAllSupportedCategories
+            ? provider.SupportedCategories.Distinct().ToArray()
+            : new[] { Category };
     }
 }
 
@@ -164,12 +221,17 @@ public partial class ProviderViewModel : ViewModelBase
 
     public UploaderCategory[] SupportedCategories { get; }
 
+    public bool SupportsMultipleCategories => SupportedCategories.Length > 1;
+
+    public string SupportedCategoriesSummary { get; }
+
     public ProviderViewModel(IUploaderProvider provider, UploaderCategory? filterCategory = null)
     {
         _providerId = provider.ProviderId;
         _name = provider.Name;
         _description = provider.Description;
         SupportedCategories = provider.SupportedCategories;
+        SupportedCategoriesSummary = string.Join(", ", SupportedCategories.Select(category => category.ToString()));
 
         // Display supported file types for the filter category if provided
         if (filterCategory.HasValue)

--- a/src/desktop/app/XerahS.UI/ViewModels/UploaderInstanceViewModel.cs
+++ b/src/desktop/app/XerahS.UI/ViewModels/UploaderInstanceViewModel.cs
@@ -188,7 +188,7 @@ public partial class UploaderInstanceViewModel : ViewModelBase
             VerifyPluginConfiguration();
 
             // Update status message to show success
-            VerificationMessage = $"Ã¢Å“â€œ Cleaned {deletedCount} duplicate DLL(s) - Please restart the application";
+            VerificationMessage = $"Cleaned {deletedCount} duplicate DLL(s). Please restart the application.";
         }
         else
         {

--- a/src/desktop/app/XerahS.UI/ViewModels/UploaderInstanceViewModel.cs
+++ b/src/desktop/app/XerahS.UI/ViewModels/UploaderInstanceViewModel.cs
@@ -25,6 +25,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using XerahS.Common;
+using XerahS.Uploaders.CustomUploader;
 using XerahS.Uploaders.PluginSystem;
 using System.Collections.ObjectModel;
 using XerahS.UI.Services;
@@ -36,10 +37,13 @@ namespace XerahS.UI.ViewModels;
 /// </summary>
 public partial class UploaderInstanceViewModel : ViewModelBase
 {
+    private bool _isSynchronizingConfigViewModel;
+
     [ObservableProperty]
     private string _instanceId = string.Empty;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsCustomUploaderInstance))]
     private string _providerId = string.Empty;
 
     [ObservableProperty]
@@ -59,10 +63,27 @@ public partial class UploaderInstanceViewModel : ViewModelBase
     private string _settingsJson = "{}";
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanManageDefinition))]
     private IUploaderConfigViewModel? _configViewModel;
 
     [ObservableProperty]
     private object? _configView;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanManageDefinition))]
+    private bool _hasDefinitionBinding;
+
+    [ObservableProperty]
+    private string _definitionFilePath = string.Empty;
+
+    [ObservableProperty]
+    private string _boundInstanceIdsDisplay = string.Empty;
+
+    [ObservableProperty]
+    private int _boundInstanceCount;
+
+    [ObservableProperty]
+    private string _definitionBindingUnavailableReason = "This instance cannot be mapped back to a .sxcu source file.";
 
     [ObservableProperty]
     private string _fileTypeScopeDisplay = string.Empty;
@@ -108,6 +129,13 @@ public partial class UploaderInstanceViewModel : ViewModelBase
     /// </summary>
     public bool IsExplorerEnabled =>
         SupportsExplorer && (ProviderCatalog.GetProvider(ProviderId)?.ValidateSettings(SettingsJson) == true);
+
+    public bool IsCustomUploaderInstance => ProviderId.StartsWith("custom_", StringComparison.OrdinalIgnoreCase);
+
+    public bool CanManageDefinition => HasDefinitionBinding && ConfigViewModel is CustomUploaderEditorViewModel;
+
+    public string DefinitionSaveHelpText =>
+        "Instance-only edits update uploader-instances.json until you use Save definition to Plugins.";
 
     /// <summary>
     /// The actual instance model
@@ -160,7 +188,7 @@ public partial class UploaderInstanceViewModel : ViewModelBase
             VerifyPluginConfiguration();
 
             // Update status message to show success
-            VerificationMessage = $"✓ Cleaned {deletedCount} duplicate DLL(s) - Please restart the application";
+            VerificationMessage = $"Ã¢Å“â€œ Cleaned {deletedCount} duplicate DLL(s) - Please restart the application";
         }
         else
         {
@@ -203,6 +231,7 @@ public partial class UploaderInstanceViewModel : ViewModelBase
 
             // Set explorer support flag after provider is resolved
             SupportsExplorer = provider is IUploaderExplorer;
+            RefreshDefinitionBindingInfo(provider as CustomUploaderProvider);
 
             if (ConfigViewModel is IProviderContextAware contextAware)
             {
@@ -216,6 +245,7 @@ public partial class UploaderInstanceViewModel : ViewModelBase
         else
         {
             Common.DebugHelper.WriteLine($"[UploaderInstanceVM] WARNING: Provider not found for ProviderId: {ProviderId}");
+            RefreshDefinitionBindingInfo();
         }
 
         if (ConfigViewModel != null)
@@ -228,12 +258,17 @@ public partial class UploaderInstanceViewModel : ViewModelBase
                 customUploaderConfigViewModel.IsNameReadOnly = true;
             }
 
-            ConfigViewModel.LoadFromJson(SettingsJson);
+            SynchronizeConfigViewModel(() => ConfigViewModel.LoadFromJson(SettingsJson));
 
             if (ConfigViewModel is ObservableObject obs)
             {
                 obs.PropertyChanged += (s, e) =>
                 {
+                    if (_isSynchronizingConfigViewModel)
+                    {
+                        return;
+                    }
+
                     // Sync settings back to JSON when any property changes
                     SettingsJson = ConfigViewModel.ToJson();
                     Instance.SettingsJson = SettingsJson;
@@ -375,7 +410,12 @@ public partial class UploaderInstanceViewModel : ViewModelBase
             customUploaderConfigViewModel.SetFallbackName(ProviderCatalog.GetProvider(ProviderId)?.Name);
         }
 
-        ConfigViewModel?.LoadFromJson(SettingsJson);
+        if (ConfigViewModel != null)
+        {
+            SynchronizeConfigViewModel(() => ConfigViewModel.LoadFromJson(SettingsJson));
+        }
+
+        RefreshDefinitionBindingInfo();
     }
 
     partial void OnDisplayNameChanged(string value)
@@ -384,12 +424,235 @@ public partial class UploaderInstanceViewModel : ViewModelBase
         InstanceManager.Instance.UpdateInstance(Instance);
     }
 
+    partial void OnProviderIdChanged(string value)
+    {
+        SupportsExplorer = ProviderCatalog.GetProvider(value) is IUploaderExplorer;
+        RefreshDefinitionBindingInfo();
+        OnPropertyChanged(nameof(IsExplorerEnabled));
+    }
+
+    [RelayCommand]
+    private async Task SaveDefinitionToPluginsAsync()
+    {
+        try
+        {
+            if (!TryGetCustomUploaderDefinitionContext(out var factory, out var provider, out var editorViewModel))
+            {
+                var unavailableFactory = UiViewModelFactoryAccessor.GetRequired();
+                await unavailableFactory.CoreDialogService.ShowWarningAsync("Save Unavailable", DefinitionBindingUnavailableReason);
+                return;
+            }
+
+            if (!editorViewModel.Validate())
+            {
+                await factory.CoreDialogService.ShowWarningAsync(
+                    "Validation Failed",
+                    "Fix the current validation errors before saving the shared .sxcu definition.");
+                return;
+            }
+
+            var bindingInfo = CustomUploaderDefinitionBindingService.GetBindingInfo(provider, InstanceId);
+            if (bindingInfo.HasMultipleBindings)
+            {
+                bool confirmed = await factory.CoreDialogService.ShowConfirmationAsync(
+                    "Save Shared Definition",
+                    $"This definition is shared by {bindingInfo.BoundInstanceIds.Count} instances. Saving it will update the shared .sxcu file for all of them.{Environment.NewLine}{Environment.NewLine}Continue?");
+
+                if (!confirmed)
+                {
+                    return;
+                }
+            }
+
+            var item = editorViewModel.ToItem();
+            if (!CustomUploaderDefinitionBindingService.SaveDefinition(
+                    item,
+                    provider.FilePath,
+                    bindingInfo.BoundInstanceIds,
+                    bindingInfo.PrimaryInstanceId))
+            {
+                await factory.CoreDialogService.ShowErrorAsync("Save Failed", "Failed to write the .sxcu definition to disk.");
+                return;
+            }
+
+            if (!ProviderCatalog.ReloadCustomUploader(provider.FilePath))
+            {
+                await factory.CoreDialogService.ShowWarningAsync(
+                    "Saved with Warning",
+                    "The .sxcu file was saved, but the provider catalog did not reload immediately.");
+            }
+
+            RefreshDefinitionBindingInfo();
+            await factory.CoreDialogService.ShowMessageAsync("Definition Saved", $"Saved changes to:{Environment.NewLine}{provider.FilePath}");
+        }
+        catch (Exception ex)
+        {
+            Common.DebugHelper.WriteException(ex, "Failed to save custom uploader definition");
+        }
+    }
+
+    [RelayCommand]
+    private async Task SaveDefinitionAsNewAsync()
+    {
+        try
+        {
+            if (!TryGetCustomUploaderDefinitionContext(out var factory, out var provider, out var editorViewModel))
+            {
+                var unavailableFactory = UiViewModelFactoryAccessor.GetRequired();
+                await unavailableFactory.CoreDialogService.ShowWarningAsync("Save Unavailable", DefinitionBindingUnavailableReason);
+                return;
+            }
+
+            if (!editorViewModel.Validate())
+            {
+                await factory.CoreDialogService.ShowWarningAsync(
+                    "Validation Failed",
+                    "Fix the current validation errors before saving a new .sxcu definition.");
+                return;
+            }
+
+            string newFilePath = CustomUploaderDefinitionBindingService.BuildForkFilePath(provider.FilePath, InstanceId);
+            var item = editorViewModel.ToItem();
+
+            if (!CustomUploaderDefinitionBindingService.SaveDefinition(item, newFilePath, new[] { InstanceId }, InstanceId))
+            {
+                await factory.CoreDialogService.ShowErrorAsync("Save Failed", "Failed to create the new .sxcu definition.");
+                return;
+            }
+
+            if (!ProviderCatalog.ReloadCustomUploader(newFilePath))
+            {
+                await factory.CoreDialogService.ShowErrorAsync(
+                    "Reload Failed",
+                    "The new .sxcu definition was written, but the provider catalog could not load it.");
+                return;
+            }
+
+            var newProvider = CustomUploaderDefinitionBindingService.GetProviderByFilePath(newFilePath);
+            if (newProvider == null)
+            {
+                await factory.CoreDialogService.ShowErrorAsync(
+                    "Reload Failed",
+                    "The new .sxcu definition was written, but no matching provider was found after reload.");
+                return;
+            }
+
+            var previousBindingInfo = CustomUploaderDefinitionBindingService.GetBindingInfo(provider, InstanceId);
+            var remainingInstanceIds = previousBindingInfo.BoundInstanceIds
+                .Where(instanceId => !string.Equals(instanceId, InstanceId, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            string? remainingPrimaryInstanceId =
+                string.Equals(previousBindingInfo.PrimaryInstanceId, InstanceId, StringComparison.OrdinalIgnoreCase)
+                    ? null
+                    : previousBindingInfo.PrimaryInstanceId;
+
+            if (!CustomUploaderDefinitionBindingService.SaveDefinition(
+                    provider.Item,
+                    provider.FilePath,
+                    remainingInstanceIds,
+                    remainingPrimaryInstanceId))
+            {
+                await factory.CoreDialogService.ShowWarningAsync(
+                    "Fork Saved with Warning",
+                    "A new .sxcu definition was created for this instance, but the original file metadata could not be updated.");
+            }
+            else
+            {
+                ProviderCatalog.ReloadCustomUploader(provider.FilePath);
+            }
+
+            editorViewModel.SetFallbackName(newProvider.Name);
+            SettingsJson = CustomUploaderSettingsSerializer.SerializeForInstance(item, newProvider.Name);
+            Instance.ProviderId = newProvider.ProviderId;
+            Instance.SettingsJson = SettingsJson;
+            ProviderId = newProvider.ProviderId;
+            InstanceManager.Instance.UpdateInstance(Instance);
+            RefreshDefinitionBindingInfo();
+
+            await factory.CoreDialogService.ShowMessageAsync(
+                "Definition Saved As New",
+                $"Saved a dedicated .sxcu definition for this instance:{Environment.NewLine}{newFilePath}");
+        }
+        catch (Exception ex)
+        {
+            Common.DebugHelper.WriteException(ex, "Failed to fork custom uploader definition");
+        }
+    }
+
+    private void SynchronizeConfigViewModel(Action action)
+    {
+        _isSynchronizingConfigViewModel = true;
+
+        try
+        {
+            action();
+        }
+        finally
+        {
+            _isSynchronizingConfigViewModel = false;
+        }
+    }
+
+    private void RefreshDefinitionBindingInfo(CustomUploaderProvider? provider = null)
+    {
+        provider ??= ProviderCatalog.GetProvider(ProviderId) as CustomUploaderProvider;
+
+        if (provider == null || string.IsNullOrWhiteSpace(provider.FilePath))
+        {
+            HasDefinitionBinding = false;
+            DefinitionFilePath = string.Empty;
+            BoundInstanceIdsDisplay = InstanceId;
+            BoundInstanceCount = string.IsNullOrWhiteSpace(InstanceId) ? 0 : 1;
+            DefinitionBindingUnavailableReason = "This instance cannot be mapped back to a .sxcu source file.";
+            return;
+        }
+
+        var bindingInfo = CustomUploaderDefinitionBindingService.GetBindingInfo(provider, InstanceId);
+
+        HasDefinitionBinding = true;
+        DefinitionFilePath = bindingInfo.FilePath;
+        BoundInstanceIdsDisplay = bindingInfo.BoundInstanceIds.Count > 0
+            ? string.Join(Environment.NewLine, bindingInfo.BoundInstanceIds)
+            : InstanceId;
+        BoundInstanceCount = bindingInfo.BoundInstanceIds.Count > 0 ? bindingInfo.BoundInstanceIds.Count : 1;
+        DefinitionBindingUnavailableReason = string.Empty;
+    }
+
+    private bool TryGetCustomUploaderDefinitionContext(
+        out IUiViewModelFactory factory,
+        out CustomUploaderProvider provider,
+        out CustomUploaderEditorViewModel editorViewModel)
+    {
+        factory = null!;
+        provider = null!;
+        editorViewModel = null!;
+
+        if (ConfigViewModel is not CustomUploaderEditorViewModel customUploaderEditorViewModel)
+        {
+            return false;
+        }
+
+        if (ProviderCatalog.GetProvider(ProviderId) is not CustomUploaderProvider customUploaderProvider ||
+            string.IsNullOrWhiteSpace(customUploaderProvider.FilePath))
+        {
+            return false;
+        }
+
+        factory = UiViewModelFactoryAccessor.GetRequired();
+        provider = customUploaderProvider;
+        editorViewModel = customUploaderEditorViewModel;
+        return true;
+    }
+
     [RelayCommand]
     private void OpenPluginsFolder()
     {
         try
         {
-            var pluginsPath = Path.Combine(PathsManager.PluginsFolder, ProviderId);
+            var customUploaderProvider = ProviderCatalog.GetProvider(ProviderId) as CustomUploaderProvider;
+            var pluginsPath = customUploaderProvider != null
+                ? Path.GetDirectoryName(customUploaderProvider.FilePath) ?? PathsManager.PluginsFolder
+                : Path.Combine(PathsManager.PluginsFolder, ProviderId);
             Common.DebugHelper.WriteLine($"[UploaderInstanceVM] Opening plugins folder: {pluginsPath}");
 
             if (!Directory.Exists(pluginsPath))

--- a/src/desktop/app/XerahS.UI/Views/CustomUploaderEditorDialog.axaml
+++ b/src/desktop/app/XerahS.UI/Views/CustomUploaderEditorDialog.axaml
@@ -52,7 +52,7 @@
 
         <!-- Action Buttons -->
         <Border Grid.Row="3" BorderThickness="0,1,0,0" BorderBrush="{DynamicResource DividerStrokeColorDefaultBrush}">
-            <Grid Margin="24,16" ColumnDefinitions="Auto,Auto,*,Auto,Auto">
+            <Grid Margin="24,16" ColumnDefinitions="Auto,Auto,Auto,*,Auto,Auto">
                 <Button Grid.Column="0" Content="Import..."
                         Command="{Binding ImportCommand}"
                         AutomationProperties.Name="Import Custom Uploader"/>
@@ -60,11 +60,16 @@
                         Command="{Binding ExportCommand}"
                         Margin="8,0,0,0"
                         AutomationProperties.Name="Export Custom Uploader"/>
+                <Button Grid.Column="2" Content="Test"
+                        Command="{Binding TestUploaderCommand}"
+                        Margin="8,0,0,0"
+                        IsEnabled="{Binding CanSave}"
+                        AutomationProperties.Name="Test Custom Uploader"/>
 
-                <Button Grid.Column="3" Content="Cancel"
+                <Button Grid.Column="4" Content="Cancel"
                         Command="{Binding CancelCommand}"
                         AutomationProperties.Name="Cancel"/>
-                <Button Grid.Column="4" Content="Save to Plugins"
+                <Button Grid.Column="5" Content="Save to Plugins"
                         Command="{Binding SaveCommand}"
                         IsEnabled="{Binding CanSave}"
                         Classes="accent"

--- a/src/desktop/app/XerahS.UI/Views/DestinationSettingsView.axaml
+++ b/src/desktop/app/XerahS.UI/Views/DestinationSettingsView.axaml
@@ -93,7 +93,7 @@
                                                    TextTrimming="CharacterEllipsis"/>
                                     </StackPanel>
 
-                                    <Button Grid.Column="4" Content="⋮" Padding="8,4"
+                                    <Button Grid.Column="4" Content="Ã¢â€¹Â®" Padding="8,4"
                                             AutomationProperties.Name="Instance Options">
                                         <Button.Flyout>
                                             <MenuFlyout>
@@ -184,6 +184,49 @@
                                              Background="{DynamicResource ControlAltFillColorDefaultBrush}"
                                              AutomationProperties.Name="Instance ID"/>
                                 </Grid>
+                            </StackPanel>
+
+                            <StackPanel Spacing="12"
+                                        IsVisible="{Binding SelectedCategory.SelectedInstance.IsCustomUploaderInstance}">
+                                <TextBlock Text="Definition Binding" FontWeight="SemiBold" FontSize="16"/>
+                                <TextBlock Text="{Binding SelectedCategory.SelectedInstance.DefinitionSaveHelpText}"
+                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                           TextWrapping="Wrap"/>
+                                <Grid ColumnDefinitions="Auto, 16, *" RowDefinitions="Auto, 16, Auto">
+                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Definition file:" VerticalAlignment="Top"/>
+                                    <TextBox Grid.Row="0" Grid.Column="2"
+                                             Text="{Binding SelectedCategory.SelectedInstance.DefinitionFilePath}"
+                                             Watermark="This instance cannot be mapped back to a .sxcu source file."
+                                             IsReadOnly="True"
+                                             Background="{DynamicResource ControlAltFillColorDefaultBrush}"
+                                             TextWrapping="Wrap"
+                                             ToolTip.Tip="{Binding SelectedCategory.SelectedInstance.DefinitionBindingUnavailableReason}"
+                                             AutomationProperties.Name="Custom Uploader Definition File"/>
+
+                                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Bound instance ID(s):" VerticalAlignment="Top"/>
+                                    <TextBox Grid.Row="2" Grid.Column="2"
+                                             Text="{Binding SelectedCategory.SelectedInstance.BoundInstanceIdsDisplay}"
+                                             IsReadOnly="True"
+                                             AcceptsReturn="True"
+                                             MinHeight="68"
+                                             Background="{DynamicResource ControlAltFillColorDefaultBrush}"
+                                             TextWrapping="Wrap"
+                                             ToolTip.Tip="Reads XerahS.instanceIds when available, otherwise falls back to the current instance binding."
+                                             AutomationProperties.Name="Bound Instance IDs"/>
+                                </Grid>
+                                <StackPanel Orientation="Horizontal" Spacing="12">
+                                    <Button Content="Save Definition to Plugins"
+                                            Command="{Binding SelectedCategory.SelectedInstance.SaveDefinitionToPluginsCommand}"
+                                            IsEnabled="{Binding SelectedCategory.SelectedInstance.CanManageDefinition}"
+                                            Classes="accent"
+                                            ToolTip.Tip="{Binding SelectedCategory.SelectedInstance.DefinitionBindingUnavailableReason}"
+                                            AutomationProperties.Name="Save Definition to Plugins"/>
+                                    <Button Content="Save as New .sxcu"
+                                            Command="{Binding SelectedCategory.SelectedInstance.SaveDefinitionAsNewCommand}"
+                                            IsEnabled="{Binding SelectedCategory.SelectedInstance.CanManageDefinition}"
+                                            ToolTip.Tip="{Binding SelectedCategory.SelectedInstance.DefinitionBindingUnavailableReason}"
+                                            AutomationProperties.Name="Save Definition As New"/>
+                                </StackPanel>
                             </StackPanel>
 
                             <!-- File Type Scope -->

--- a/src/desktop/app/XerahS.UI/Views/DestinationSettingsView.axaml
+++ b/src/desktop/app/XerahS.UI/Views/DestinationSettingsView.axaml
@@ -93,7 +93,7 @@
                                                    TextTrimming="CharacterEllipsis"/>
                                     </StackPanel>
 
-                                    <Button Grid.Column="4" Content="Ã¢â€¹Â®" Padding="8,4"
+                                    <Button Grid.Column="4" Content="..." Padding="8,4"
                                             AutomationProperties.Name="Instance Options">
                                         <Button.Flyout>
                                             <MenuFlyout>

--- a/src/desktop/app/XerahS.UI/Views/ProviderCatalogView.axaml
+++ b/src/desktop/app/XerahS.UI/Views/ProviderCatalogView.axaml
@@ -111,19 +111,34 @@
                 BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
                 BorderThickness="0,1,0,0"
                 Padding="24">
-            <StackPanel Orientation="Horizontal" 
-                        HorizontalAlignment="Right"
-                        Spacing="12">
-                <Button Content="Cancel" 
-                        Command="{Binding CancelCommand}"
-                        MinWidth="90"
-                        AutomationProperties.Name="Cancel Selection"/>
-                <Button Content="Add Selected" 
-                        Command="{Binding AddSelectedCommand}"
-                        Classes="accent"
-                        MinWidth="110"
-                        AutomationProperties.Name="Add Selected Provider"/>
-            </StackPanel>
+            <Grid ColumnDefinitions="*,Auto">
+                <StackPanel Grid.Column="0"
+                            Spacing="6"
+                            IsVisible="{Binding CanAddToAllSupportedCategories}">
+                    <CheckBox Content="Add to all supported categories"
+                              IsChecked="{Binding AddToAllSupportedCategories}"
+                              AutomationProperties.Name="Add To All Supported Categories"/>
+                    <TextBlock Text="{Binding MultiCategorySelectionSummary, StringFormat='Supported categories: {0}'}"
+                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                               FontSize="11"
+                               TextWrapping="Wrap"/>
+                </StackPanel>
+
+                <StackPanel Grid.Column="1"
+                            Orientation="Horizontal" 
+                            HorizontalAlignment="Right"
+                            Spacing="12">
+                    <Button Content="Cancel" 
+                            Command="{Binding CancelCommand}"
+                            MinWidth="90"
+                            AutomationProperties.Name="Cancel Selection"/>
+                    <Button Content="Add Selected" 
+                            Command="{Binding AddSelectedCommand}"
+                            Classes="accent"
+                            MinWidth="110"
+                            AutomationProperties.Name="Add Selected Provider"/>
+                </StackPanel>
+            </Grid>
         </Border>
     </Grid>
 </UserControl>

--- a/src/desktop/core/XerahS.Uploaders/CustomUploader/CustomUploaderDefinitionBindingService.cs
+++ b/src/desktop/core/XerahS.Uploaders/CustomUploader/CustomUploaderDefinitionBindingService.cs
@@ -1,0 +1,247 @@
+#region License Information (GPL v3)
+
+/*
+    XerahS - The Avalonia UI implementation of ShareX
+    Copyright (c) 2007-2026 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using Newtonsoft.Json;
+using XerahS.Common;
+using XerahS.Uploaders.PluginSystem;
+
+namespace XerahS.Uploaders.CustomUploader;
+
+public sealed class CustomUploaderXerahSMetadata
+{
+    [JsonProperty("instanceIds")]
+    public List<string> InstanceIds { get; set; } = new();
+
+    [JsonProperty("primaryInstanceId")]
+    public string? PrimaryInstanceId { get; set; }
+
+    [JsonIgnore]
+    public bool HasBindings => InstanceIds.Count > 0 || !string.IsNullOrWhiteSpace(PrimaryInstanceId);
+
+    public CustomUploaderXerahSMetadata Normalize()
+    {
+        InstanceIds = InstanceIds
+            .Where(instanceId => !string.IsNullOrWhiteSpace(instanceId))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (!string.IsNullOrWhiteSpace(PrimaryInstanceId) &&
+            !InstanceIds.Contains(PrimaryInstanceId, StringComparer.OrdinalIgnoreCase))
+        {
+            InstanceIds.Insert(0, PrimaryInstanceId);
+        }
+
+        if (string.IsNullOrWhiteSpace(PrimaryInstanceId) && InstanceIds.Count == 1)
+        {
+            PrimaryInstanceId = InstanceIds[0];
+        }
+
+        return this;
+    }
+
+    public static CustomUploaderXerahSMetadata? FromInstanceIds(IEnumerable<string>? instanceIds, string? primaryInstanceId = null)
+    {
+        var metadata = new CustomUploaderXerahSMetadata
+        {
+            PrimaryInstanceId = primaryInstanceId
+        };
+
+        if (instanceIds != null)
+        {
+            metadata.InstanceIds.AddRange(instanceIds);
+        }
+
+        metadata.Normalize();
+        return metadata.HasBindings ? metadata : null;
+    }
+}
+
+public sealed class CustomUploaderDefinitionBindingInfo
+{
+    public string FilePath { get; init; } = string.Empty;
+    public IReadOnlyList<string> BoundInstanceIds { get; init; } = Array.Empty<string>();
+    public string? PrimaryInstanceId { get; init; }
+    public bool HasMultipleBindings => BoundInstanceIds.Count > 1;
+}
+
+public sealed class CustomUploaderInstanceCreationResult
+{
+    public List<UploaderInstance> CreatedInstances { get; } = new();
+    public List<UploaderCategory> SkippedCategories { get; } = new();
+
+    public IReadOnlyList<UploaderCategory> AffectedCategories =>
+        CreatedInstances.Select(instance => instance.Category)
+            .Concat(SkippedCategories)
+            .Distinct()
+            .ToList();
+}
+
+public static class CustomUploaderDefinitionBindingService
+{
+    public static CustomUploaderProvider? GetProviderByFilePath(string filePath)
+    {
+        return ProviderCatalog.GetCustomUploaderProviderByFilePath(filePath);
+    }
+
+    public static CustomUploaderDefinitionBindingInfo GetBindingInfo(CustomUploaderProvider provider, string? fallbackInstanceId = null)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+
+        var metadataInstanceIds = provider.Metadata?.InstanceIds
+            .Where(instanceId => !string.IsNullOrWhiteSpace(instanceId))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var boundInstanceIds = metadataInstanceIds is { Count: > 0 }
+            ? metadataInstanceIds
+            : GetBoundInstanceIds(provider.ProviderId, fallbackInstanceId);
+
+        if (boundInstanceIds.Count == 0 && !string.IsNullOrWhiteSpace(fallbackInstanceId))
+        {
+            boundInstanceIds.Add(fallbackInstanceId);
+        }
+
+        string? primaryInstanceId = provider.Metadata?.PrimaryInstanceId;
+        if (string.IsNullOrWhiteSpace(primaryInstanceId) && boundInstanceIds.Count == 1)
+        {
+            primaryInstanceId = boundInstanceIds[0];
+        }
+
+        return new CustomUploaderDefinitionBindingInfo
+        {
+            FilePath = provider.FilePath,
+            BoundInstanceIds = boundInstanceIds,
+            PrimaryInstanceId = primaryInstanceId
+        };
+    }
+
+    public static List<string> GetBoundInstanceIds(string providerId, string? fallbackInstanceId = null)
+    {
+        var instanceIds = InstanceManager.Instance.GetInstances()
+            .Where(instance => string.Equals(instance.ProviderId, providerId, StringComparison.OrdinalIgnoreCase))
+            .Select(instance => instance.InstanceId)
+            .Where(instanceId => !string.IsNullOrWhiteSpace(instanceId))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (instanceIds.Count == 0 && !string.IsNullOrWhiteSpace(fallbackInstanceId))
+        {
+            instanceIds.Add(fallbackInstanceId);
+        }
+
+        return instanceIds;
+    }
+
+    public static CustomUploaderInstanceCreationResult CreateMissingInstances(CustomUploaderProvider provider)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+
+        var result = new CustomUploaderInstanceCreationResult();
+
+        foreach (var category in provider.SupportedCategories.Distinct())
+        {
+            bool alreadyExists = InstanceManager.Instance
+                .GetInstancesByCategory(category)
+                .Any(instance => string.Equals(instance.ProviderId, provider.ProviderId, StringComparison.OrdinalIgnoreCase));
+
+            if (alreadyExists)
+            {
+                result.SkippedCategories.Add(category);
+                continue;
+            }
+
+            var instance = new UploaderInstance
+            {
+                ProviderId = provider.ProviderId,
+                Category = category,
+                DisplayName = provider.Name,
+                SettingsJson = provider.GetDefaultSettings(category),
+                FileTypeRouting = new FileTypeScope { AllFileTypes = true }
+            };
+
+            InstanceManager.Instance.AddInstance(instance);
+            result.CreatedInstances.Add(instance);
+        }
+
+        return result;
+    }
+
+    public static bool SaveDefinition(
+        CustomUploaderItem item,
+        string filePath,
+        IEnumerable<string>? instanceIds,
+        string? primaryInstanceId = null)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        var metadata = CustomUploaderXerahSMetadata.FromInstanceIds(instanceIds, primaryInstanceId);
+        return CustomUploaderRepository.SaveToFile(item, filePath, metadata);
+    }
+
+    public static bool SaveDefinition(CustomUploaderProvider provider, CustomUploaderItem item, string? fallbackInstanceId = null)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+        ArgumentNullException.ThrowIfNull(item);
+
+        var bindingInfo = GetBindingInfo(provider, fallbackInstanceId);
+        return SaveDefinition(item, provider.FilePath, bindingInfo.BoundInstanceIds, bindingInfo.PrimaryInstanceId);
+    }
+
+    public static string BuildForkFilePath(string sourceFilePath, string instanceId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceFilePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(instanceId);
+
+        string directory = Path.GetDirectoryName(sourceFilePath) ?? PathsManager.PluginsFolder;
+        string baseName = MakeSafeFileName(Path.GetFileNameWithoutExtension(sourceFilePath));
+        string shortInstanceId = instanceId.Length > 8 ? instanceId[..8] : instanceId;
+
+        string filePath = Path.Combine(directory, $"{baseName}__xerahs-{shortInstanceId}.sxcu");
+        int counter = 0;
+
+        while (File.Exists(filePath))
+        {
+            counter++;
+            filePath = Path.Combine(directory, $"{baseName}__xerahs-{shortInstanceId}_{counter}.sxcu");
+        }
+
+        return filePath;
+    }
+
+    private static string MakeSafeFileName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return "CustomUploader";
+        }
+
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var safeName = new string(name.Where(character => !invalidChars.Contains(character)).ToArray());
+        safeName = safeName.Replace(' ', '_');
+
+        return string.IsNullOrWhiteSpace(safeName) ? "CustomUploader" : safeName;
+    }
+}

--- a/src/desktop/core/XerahS.Uploaders/CustomUploader/CustomUploaderProvider.cs
+++ b/src/desktop/core/XerahS.Uploaders/CustomUploader/CustomUploaderProvider.cs
@@ -38,13 +38,14 @@ public class CustomUploaderProvider : IUploaderProvider
     private readonly CustomUploaderItem _item;
     private readonly string _filePath;
     private readonly string _providerId;
+    private readonly CustomUploaderXerahSMetadata? _metadata;
 
     /// <summary>
     /// Creates a new CustomUploaderProvider from a loaded custom uploader.
     /// </summary>
     /// <param name="loadedUploader">The loaded custom uploader from repository.</param>
     public CustomUploaderProvider(LoadedCustomUploader loadedUploader)
-        : this(loadedUploader.Item, loadedUploader.FilePath)
+        : this(loadedUploader.Item, loadedUploader.FilePath, loadedUploader.Metadata)
     {
     }
 
@@ -53,10 +54,12 @@ public class CustomUploaderProvider : IUploaderProvider
     /// </summary>
     /// <param name="item">The custom uploader configuration.</param>
     /// <param name="filePath">Source file path (used for ID generation).</param>
-    public CustomUploaderProvider(CustomUploaderItem item, string filePath)
+    /// <param name="metadata">Optional XerahS-specific metadata loaded from the source file.</param>
+    public CustomUploaderProvider(CustomUploaderItem item, string filePath, CustomUploaderXerahSMetadata? metadata = null)
     {
         _item = item ?? throw new ArgumentNullException(nameof(item));
         _filePath = filePath;
+        _metadata = metadata?.Normalize();
 
         // Generate a stable provider ID based on name and file
         _providerId = GenerateProviderId(item, filePath);
@@ -155,6 +158,11 @@ public class CustomUploaderProvider : IUploaderProvider
     /// The underlying CustomUploaderItem configuration.
     /// </summary>
     public CustomUploaderItem Item => _item;
+
+    /// <summary>
+    /// Optional XerahS-specific metadata loaded from the source file.
+    /// </summary>
+    public CustomUploaderXerahSMetadata? Metadata => _metadata;
 
     /// <inheritdoc/>
     public object? CreateConfigView()

--- a/src/desktop/core/XerahS.Uploaders/CustomUploader/CustomUploaderRepository.cs
+++ b/src/desktop/core/XerahS.Uploaders/CustomUploader/CustomUploaderRepository.cs
@@ -24,6 +24,7 @@
 #endregion License Information (GPL v3)
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using XerahS.Common;
 
 namespace XerahS.Uploaders.CustomUploader;
@@ -37,6 +38,11 @@ public class LoadedCustomUploader
     /// The parsed CustomUploaderItem configuration.
     /// </summary>
     public CustomUploaderItem Item { get; }
+
+    /// <summary>
+    /// Optional XerahS-specific metadata stored alongside the ShareX-compatible root fields.
+    /// </summary>
+    public CustomUploaderXerahSMetadata? Metadata { get; }
 
     /// <summary>
     /// Full path to the source .sxcu or .json file.
@@ -58,9 +64,10 @@ public class LoadedCustomUploader
     /// </summary>
     public bool IsValid => LoadError == null;
 
-    public LoadedCustomUploader(CustomUploaderItem item, string filePath)
+    public LoadedCustomUploader(CustomUploaderItem item, string filePath, CustomUploaderXerahSMetadata? metadata = null)
     {
         Item = item;
+        Metadata = metadata;
         FilePath = filePath;
         FileNameWithoutExtension = Path.GetFileNameWithoutExtension(filePath);
         LoadError = null;
@@ -69,6 +76,7 @@ public class LoadedCustomUploader
     public LoadedCustomUploader(string filePath, string error)
     {
         Item = CustomUploaderItem.Init();
+        Metadata = null;
         FilePath = filePath;
         FileNameWithoutExtension = Path.GetFileNameWithoutExtension(filePath);
         LoadError = error;
@@ -165,7 +173,9 @@ public static class CustomUploaderRepository
     {
         try
         {
-            var item = JsonConvert.DeserializeObject<CustomUploaderItem>(json);
+            var root = JObject.Parse(json);
+            var metadata = ExtractMetadata(root);
+            var item = root.ToObject<CustomUploaderItem>();
 
             if (item == null)
             {
@@ -189,7 +199,7 @@ public static class CustomUploaderRepository
                 return new LoadedCustomUploader(sourcePath, $"Compatibility check failed: {ex.Message}");
             }
 
-            return new LoadedCustomUploader(item, sourcePath);
+            return new LoadedCustomUploader(item, sourcePath, metadata);
         }
         catch (JsonException ex)
         {
@@ -239,15 +249,34 @@ public static class CustomUploaderRepository
     /// <returns>True if saved successfully.</returns>
     public static bool SaveToFile(CustomUploaderItem item, string filePath)
     {
+        return SaveToFile(item, filePath, metadata: null);
+    }
+
+    /// <summary>
+    /// Saves a custom uploader to a file with optional XerahS-specific metadata.
+    /// </summary>
+    /// <param name="item">The custom uploader item to save.</param>
+    /// <param name="filePath">Destination file path.</param>
+    /// <param name="metadata">Optional metadata persisted under the root XerahS object.</param>
+    /// <returns>True if saved successfully.</returns>
+    public static bool SaveToFile(CustomUploaderItem item, string filePath, CustomUploaderXerahSMetadata? metadata)
+    {
         try
         {
-            var json = JsonConvert.SerializeObject(item, Formatting.Indented, new JsonSerializerSettings
+            var serializer = JsonSerializer.Create(new JsonSerializerSettings
             {
                 DefaultValueHandling = DefaultValueHandling.Ignore,
                 NullValueHandling = NullValueHandling.Ignore
             });
+            var root = JObject.FromObject(item, serializer);
+            var normalizedMetadata = metadata?.Normalize();
 
-            File.WriteAllText(filePath, json);
+            if (normalizedMetadata?.HasBindings == true)
+            {
+                root["XerahS"] = JObject.FromObject(normalizedMetadata, serializer);
+            }
+
+            File.WriteAllText(filePath, root.ToString(Formatting.Indented));
             DebugHelper.WriteLine($"[CustomUploader] Saved uploader to: {filePath}");
             return true;
         }
@@ -314,6 +343,29 @@ public static class CustomUploaderRepository
         lock (_lock)
         {
             _loadedUploaders.Remove(filePath);
+        }
+    }
+
+    private static CustomUploaderXerahSMetadata? ExtractMetadata(JObject root)
+    {
+        var metadataProperty = root.Properties()
+            .FirstOrDefault(property => string.Equals(property.Name, "XerahS", StringComparison.OrdinalIgnoreCase));
+
+        if (metadataProperty == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var metadata = metadataProperty.Value.ToObject<CustomUploaderXerahSMetadata>()?.Normalize();
+            metadataProperty.Remove();
+            return metadata?.HasBindings == true ? metadata : null;
+        }
+        catch
+        {
+            metadataProperty.Remove();
+            return null;
         }
     }
 }

--- a/src/desktop/core/XerahS.Uploaders/PluginSystem/ProviderCatalog.cs
+++ b/src/desktop/core/XerahS.Uploaders/PluginSystem/ProviderCatalog.cs
@@ -112,13 +112,13 @@ public static class ProviderCatalog
                     else
                     {
                         failureCount++;
-                        DebugHelper.WriteLine($"[Plugins] ✗ FAILED: {metadata.Manifest.Name} - {metadata.LoadError}");
+                        DebugHelper.WriteLine($"[Plugins] Ã¢Å“â€” FAILED: {metadata.Manifest.Name} - {metadata.LoadError}");
                     }
                 }
                 catch (Exception ex)
                 {
                     failureCount++;
-                    DebugHelper.WriteLine($"[Plugins] ✗ ERROR loading {metadata.Manifest.Name}: {ex.Message}");
+                    DebugHelper.WriteLine($"[Plugins] Ã¢Å“â€” ERROR loading {metadata.Manifest.Name}: {ex.Message}");
                     DebugHelper.WriteLine($"[Plugins]   Stack: {ex.StackTrace}");
                 }
             }
@@ -340,18 +340,18 @@ public static class ProviderCatalog
                     _pluginMetadata[provider.ProviderId] = metadata;
 
                     loadedCount++;
-                    DebugHelper.WriteLine($"[CustomUploader] ✓ Loaded: {provider.Name} ({provider.ProviderId}) - Categories: {string.Join(", ", provider.SupportedCategories)}");
+                    DebugHelper.WriteLine($"[CustomUploader] Ã¢Å“â€œ Loaded: {provider.Name} ({provider.ProviderId}) - Categories: {string.Join(", ", provider.SupportedCategories)}");
                 }
                 catch (Exception ex)
                 {
-                    DebugHelper.WriteLine($"[CustomUploader] ✗ Error creating provider for {uploader.FilePath}: {ex.Message}");
+                    DebugHelper.WriteLine($"[CustomUploader] Ã¢Å“â€” Error creating provider for {uploader.FilePath}: {ex.Message}");
                 }
             }
 
             // Log failures
             foreach (var uploader in loaded.Where(u => !u.IsValid))
             {
-                DebugHelper.WriteLine($"[CustomUploader] ✗ Failed to load {uploader.FilePath}: {uploader.LoadError}");
+                DebugHelper.WriteLine($"[CustomUploader] Ã¢Å“â€” Failed to load {uploader.FilePath}: {uploader.LoadError}");
             }
         }
 
@@ -410,6 +410,21 @@ public static class ProviderCatalog
     }
 
     /// <summary>
+    /// Gets a custom uploader provider by its backing file path.
+    /// </summary>
+    /// <param name="filePath">Full path to the custom uploader definition file.</param>
+    /// <returns>The matching provider if one is loaded; otherwise null.</returns>
+    public static CustomUploaderProvider? GetCustomUploaderProviderByFilePath(string filePath)
+    {
+        lock (_lock)
+        {
+            return _providers.Values
+                .OfType<CustomUploaderProvider>()
+                .FirstOrDefault(provider => string.Equals(provider.FilePath, filePath, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    /// <summary>
     /// Reloads a specific custom uploader file
     /// </summary>
     /// <param name="filePath">Path to the .sxcu file to reload</param>
@@ -429,7 +444,8 @@ public static class ProviderCatalog
 
             // Remove old provider with same file if exists
             var existingKey = _providers.Keys.FirstOrDefault(k =>
-                _providers[k] is CustomUploaderProvider cp && cp.FilePath == filePath);
+                _providers[k] is CustomUploaderProvider cp &&
+                string.Equals(cp.FilePath, filePath, StringComparison.OrdinalIgnoreCase));
 
             if (existingKey != null)
             {

--- a/src/desktop/core/XerahS.Uploaders/PluginSystem/ProviderCatalog.cs
+++ b/src/desktop/core/XerahS.Uploaders/PluginSystem/ProviderCatalog.cs
@@ -112,13 +112,13 @@ public static class ProviderCatalog
                     else
                     {
                         failureCount++;
-                        DebugHelper.WriteLine($"[Plugins] Ã¢Å“â€” FAILED: {metadata.Manifest.Name} - {metadata.LoadError}");
+                        DebugHelper.WriteLine($"[Plugins] [FAIL] {metadata.Manifest.Name} - {metadata.LoadError}");
                     }
                 }
                 catch (Exception ex)
                 {
                     failureCount++;
-                    DebugHelper.WriteLine($"[Plugins] Ã¢Å“â€” ERROR loading {metadata.Manifest.Name}: {ex.Message}");
+                    DebugHelper.WriteLine($"[Plugins] [ERROR] loading {metadata.Manifest.Name}: {ex.Message}");
                     DebugHelper.WriteLine($"[Plugins]   Stack: {ex.StackTrace}");
                 }
             }
@@ -340,18 +340,18 @@ public static class ProviderCatalog
                     _pluginMetadata[provider.ProviderId] = metadata;
 
                     loadedCount++;
-                    DebugHelper.WriteLine($"[CustomUploader] Ã¢Å“â€œ Loaded: {provider.Name} ({provider.ProviderId}) - Categories: {string.Join(", ", provider.SupportedCategories)}");
+                    DebugHelper.WriteLine($"[CustomUploader] [OK] Loaded: {provider.Name} ({provider.ProviderId}) - Categories: {string.Join(", ", provider.SupportedCategories)}");
                 }
                 catch (Exception ex)
                 {
-                    DebugHelper.WriteLine($"[CustomUploader] Ã¢Å“â€” Error creating provider for {uploader.FilePath}: {ex.Message}");
+                    DebugHelper.WriteLine($"[CustomUploader] [ERROR] creating provider for {uploader.FilePath}: {ex.Message}");
                 }
             }
 
             // Log failures
             foreach (var uploader in loaded.Where(u => !u.IsValid))
             {
-                DebugHelper.WriteLine($"[CustomUploader] Ã¢Å“â€” Failed to load {uploader.FilePath}: {uploader.LoadError}");
+                DebugHelper.WriteLine($"[CustomUploader] [FAIL] Failed to load {uploader.FilePath}: {uploader.LoadError}");
             }
         }
 

--- a/tests/XerahS.Tests/CustomUploader/CustomUploaderDefinitionBindingServiceTests.cs
+++ b/tests/XerahS.Tests/CustomUploader/CustomUploaderDefinitionBindingServiceTests.cs
@@ -1,0 +1,217 @@
+#region License Information (GPL v3)
+
+/*
+    XerahS - The Avalonia UI implementation of ShareX
+    Copyright (c) 2007-2026 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using NUnit.Framework;
+using XerahS.Common;
+using XerahS.Core;
+using XerahS.UI.ViewModels;
+using XerahS.Uploaders;
+using XerahS.Uploaders.CustomUploader;
+using XerahS.Uploaders.PluginSystem;
+
+namespace XerahS.Tests.CustomUploader;
+
+[TestFixture]
+[NonParallelizable]
+public class CustomUploaderDefinitionBindingServiceTests
+{
+    private string _rootPath = null!;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _rootPath = Path.Combine(Path.GetTempPath(), "XerahS.Tests", "XIP0056", Guid.NewGuid().ToString("N"));
+        var personalFolder = Path.Combine(_rootPath, "Personal");
+
+        Directory.CreateDirectory(_rootPath);
+        PathsManager.PersonalFolder = personalFolder;
+        SettingsManager.PersonalFolder = personalFolder;
+        PathsManager.EnsureDirectoriesExist();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        CleanupProviders();
+        ClearInstances();
+
+        if (Directory.Exists(_rootPath))
+        {
+            Directory.Delete(_rootPath, recursive: true);
+        }
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        CleanupProviders();
+        ClearInstances();
+    }
+
+    [TestCase(CustomUploaderDestinationType.ImageUploader, UploaderCategory.Image)]
+    [TestCase(CustomUploaderDestinationType.FileUploader, UploaderCategory.File)]
+    [TestCase(CustomUploaderDestinationType.ImageUploader | CustomUploaderDestinationType.FileUploader, UploaderCategory.Image, UploaderCategory.File)]
+    public void CreateMissingInstances_RespectsDestinationTypes(
+        CustomUploaderDestinationType destinationType,
+        params UploaderCategory[] expectedCategories)
+    {
+        string filePath = CreateUniqueFilePath("destinations");
+        var item = CreateItem(destinationType);
+
+        Assert.That(CustomUploaderRepository.SaveToFile(item, filePath), Is.True);
+        Assert.That(ProviderCatalog.ReloadCustomUploader(filePath), Is.True);
+
+        var provider = CustomUploaderDefinitionBindingService.GetProviderByFilePath(filePath);
+        Assert.That(provider, Is.Not.Null);
+
+        var result = CustomUploaderDefinitionBindingService.CreateMissingInstances(provider!);
+
+        Assert.That(result.CreatedInstances.Select(instance => instance.Category), Is.EquivalentTo(expectedCategories));
+        Assert.That(result.SkippedCategories, Is.Empty);
+    }
+
+    [Test]
+    public void CreateMissingInstances_IsIdempotent_AndPersistsInstanceIdsMetadata()
+    {
+        string filePath = CreateUniqueFilePath("metadata");
+        var item = CreateItem(CustomUploaderDestinationType.ImageUploader | CustomUploaderDestinationType.FileUploader);
+
+        Assert.That(CustomUploaderRepository.SaveToFile(item, filePath), Is.True);
+        Assert.That(ProviderCatalog.ReloadCustomUploader(filePath), Is.True);
+
+        var provider = CustomUploaderDefinitionBindingService.GetProviderByFilePath(filePath);
+        Assert.That(provider, Is.Not.Null);
+
+        var firstResult = CustomUploaderDefinitionBindingService.CreateMissingInstances(provider!);
+        var firstBoundIds = CustomUploaderDefinitionBindingService.GetBoundInstanceIds(provider!.ProviderId);
+
+        Assert.That(firstResult.CreatedInstances.Count, Is.EqualTo(2));
+        Assert.That(CustomUploaderDefinitionBindingService.SaveDefinition(provider.Item, provider.FilePath, firstBoundIds), Is.True);
+        Assert.That(ProviderCatalog.ReloadCustomUploader(filePath), Is.True);
+
+        var reloaded = CustomUploaderRepository.LoadFromFile(filePath);
+        Assert.That(reloaded.IsValid, Is.True, reloaded.LoadError);
+        Assert.That(reloaded.Metadata, Is.Not.Null);
+        Assert.That(reloaded.Metadata!.InstanceIds, Is.EquivalentTo(firstBoundIds));
+
+        var reloadedProvider = CustomUploaderDefinitionBindingService.GetProviderByFilePath(filePath);
+        Assert.That(reloadedProvider, Is.Not.Null);
+
+        var secondResult = CustomUploaderDefinitionBindingService.CreateMissingInstances(reloadedProvider!);
+
+        Assert.That(secondResult.CreatedInstances, Is.Empty);
+        Assert.That(secondResult.SkippedCategories, Is.EquivalentTo(new[] { UploaderCategory.Image, UploaderCategory.File }));
+    }
+
+    [Test]
+    public void GetBindingInfo_FallsBackToCurrentInstance_WhenMetadataIsMissing()
+    {
+        string filePath = CreateUniqueFilePath("fallback");
+        var item = CreateItem(CustomUploaderDestinationType.TextUploader);
+
+        Assert.That(CustomUploaderRepository.SaveToFile(item, filePath), Is.True);
+        Assert.That(ProviderCatalog.ReloadCustomUploader(filePath), Is.True);
+
+        var provider = CustomUploaderDefinitionBindingService.GetProviderByFilePath(filePath);
+        Assert.That(provider, Is.Not.Null);
+
+        var createResult = CustomUploaderDefinitionBindingService.CreateMissingInstances(provider!);
+        Assert.That(createResult.CreatedInstances.Count, Is.EqualTo(1));
+
+        var bindingInfo = CustomUploaderDefinitionBindingService.GetBindingInfo(provider!, createResult.CreatedInstances[0].InstanceId);
+
+        Assert.That(bindingInfo.BoundInstanceIds, Is.EquivalentTo(new[] { createResult.CreatedInstances[0].InstanceId }));
+        Assert.That(bindingInfo.PrimaryInstanceId, Is.EqualTo(createResult.CreatedInstances[0].InstanceId));
+    }
+
+    [Test]
+    public void ProviderCatalogViewModel_AddSelected_CanAddToAllSupportedCategories()
+    {
+        string filePath = CreateUniqueFilePath("catalog");
+        var item = CreateItem(CustomUploaderDestinationType.ImageUploader | CustomUploaderDestinationType.FileUploader);
+
+        Assert.That(CustomUploaderRepository.SaveToFile(item, filePath), Is.True);
+        Assert.That(ProviderCatalog.ReloadCustomUploader(filePath), Is.True);
+
+        var provider = CustomUploaderDefinitionBindingService.GetProviderByFilePath(filePath);
+        Assert.That(provider, Is.Not.Null);
+
+        var viewModel = new ProviderCatalogViewModel(UploaderCategory.Image);
+        viewModel.SelectedProvider = viewModel.AvailableProviders.Single(candidate => candidate.ProviderId == provider!.ProviderId);
+
+        List<UploaderInstance>? addedInstances = null;
+        viewModel.OnInstancesAdded = instances => addedInstances = instances;
+
+        viewModel.AddSelectedCommand.Execute(null);
+
+        Assert.That(addedInstances, Is.Not.Null);
+        Assert.That(addedInstances!.Select(instance => instance.Category), Is.EquivalentTo(new[] { UploaderCategory.Image, UploaderCategory.File }));
+
+        var reloaded = CustomUploaderRepository.LoadFromFile(filePath);
+        Assert.That(reloaded.IsValid, Is.True, reloaded.LoadError);
+        Assert.That(reloaded.Metadata, Is.Not.Null);
+        Assert.That(reloaded.Metadata!.InstanceIds.Count, Is.EqualTo(2));
+    }
+
+    private static CustomUploaderItem CreateItem(CustomUploaderDestinationType destinationType)
+    {
+        var item = CustomUploaderItem.Init();
+        item.Name = $"Test {destinationType}";
+        item.DestinationType = destinationType;
+        item.RequestURL = "https://example.com/upload";
+        item.RequestMethod = XerahS.Uploaders.HttpMethod.POST;
+        item.Body = CustomUploaderBody.MultipartFormData;
+        item.FileFormName = "file";
+        item.URL = "{response}";
+        return item;
+    }
+
+    private string CreateUniqueFilePath(string folderName)
+    {
+        string directory = Path.Combine(_rootPath, folderName);
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, $"{Guid.NewGuid():N}.sxcu");
+    }
+
+    private static void ClearInstances()
+    {
+        foreach (var instance in InstanceManager.Instance.GetInstances().ToList())
+        {
+            InstanceManager.Instance.RemoveInstance(instance.InstanceId);
+        }
+    }
+
+    private void CleanupProviders()
+    {
+        foreach (var provider in ProviderCatalog.GetCustomUploaderProviders()
+                     .Where(provider => provider.FilePath.StartsWith(_rootPath, StringComparison.OrdinalIgnoreCase))
+                     .ToList())
+        {
+            ProviderCatalog.RemoveCustomUploader(provider.ProviderId);
+        }
+
+        CustomUploaderRepository.Clear();
+    }
+}


### PR DESCRIPTION
This pull request introduces several improvements to the custom uploader workflow and provider management in the application. The main changes focus on making custom uploader instance creation more robust and user-friendly, enhancing the provider catalog's multi-category support, and improving validation and feedback for uploader configuration. Additionally, there are minor documentation and usability updates.

**Custom uploader instance management and feedback:**

* Refactored custom uploader instance creation to use a new `EnsureCustomUploaderInstances` method, which reloads providers, creates missing instances, updates metadata, and provides detailed feedback on created or reused instances. This method is now used during import and creation flows, and the user is shown a more informative message about the result. [[1]](diffhunk://#diff-d47ed3b1a2016610cc7e037dd62950509f12973e93e4733d0a81247b564d2424L189-R201) [[2]](diffhunk://#diff-d47ed3b1a2016610cc7e037dd62950509f12973e93e4733d0a81247b564d2424L284-R289) [[3]](diffhunk://#diff-d47ed3b1a2016610cc7e037dd62950509f12973e93e4733d0a81247b564d2424L310-R401)
* Improved import summary and creation dialogs to clearly state when instances are created, reused, or when no changes occurred, using new helper methods for formatting category lists and messages. [[1]](diffhunk://#diff-d47ed3b1a2016610cc7e037dd62950509f12973e93e4733d0a81247b564d2424L504-R562) [[2]](diffhunk://#diff-d47ed3b1a2016610cc7e037dd62950509f12973e93e4733d0a81247b564d2424L310-R401)

**Provider catalog enhancements:**

* Added support for adding providers to all supported categories at once, with UI state and summary properties reflecting multi-category support. The provider catalog now prevents duplicate instance creation and updates custom uploader metadata and bindings after adding instances. [[1]](diffhunk://#diff-5328ea0151cd4a5142a7e7126dfe2f022df17a2adc0371da070df3180d7ded59R49-R58) [[2]](diffhunk://#diff-5328ea0151cd4a5142a7e7126dfe2f022df17a2adc0371da070df3180d7ded59R82-R96) [[3]](diffhunk://#diff-5328ea0151cd4a5142a7e7126dfe2f022df17a2adc0371da070df3180d7ded59R130-R167) [[4]](diffhunk://#diff-5328ea0151cd4a5142a7e7126dfe2f022df17a2adc0371da070df3180d7ded59R181-R187) [[5]](diffhunk://#diff-5328ea0151cd4a5142a7e7126dfe2f022df17a2adc0371da070df3180d7ded59R224-R234)
* Provider selection now updates UI state to reflect whether multi-category addition is available and provides a summary of supported categories. [[1]](diffhunk://#diff-5328ea0151cd4a5142a7e7126dfe2f022df17a2adc0371da070df3180d7ded59R82-R96) [[2]](diffhunk://#diff-5328ea0151cd4a5142a7e7126dfe2f022df17a2adc0371da070df3180d7ded59R224-R234)

**Uploader configuration validation and feedback:**

* The custom uploader test now provides a detailed preview of the resolved request, including URL, HTTP method, body, parameters, headers, form arguments, and response extraction rules, without making a network request. Several new helper methods were added to format and describe the preview. [[1]](diffhunk://#diff-ca508c10e002d267834f8392ff9da3c95fa83fd14ac945ef667aaae52654f351R36) [[2]](diffhunk://#diff-ca508c10e002d267834f8392ff9da3c95fa83fd14ac945ef667aaae52654f351L449-R494) [[3]](diffhunk://#diff-ca508c10e002d267834f8392ff9da3c95fa83fd14ac945ef667aaae52654f351R665-R714)

**Other improvements and documentation:**

* Added a new lesson-learned guideline to avoid using decorative Unicode glyphs in UI labels unless explicitly verified, to prevent encoding issues.
* Minor usability improvements, such as refreshing category instances when selection changes and ensuring category lists are up to date after imports. [[1]](diffhunk://#diff-d47ed3b1a2016610cc7e037dd62950509f12973e93e4733d0a81247b564d2424R150-R154) [[2]](diffhunk://#diff-d47ed3b1a2016610cc7e037dd62950509f12973e93e4733d0a81247b564d2424L189-R201)

These changes together make the custom uploader and provider management experience more robust, informative, and less error-prone for users and developers.