### PR TITLE
Codex/xip0055 send to upload behavior control

### DIFF
--- a/developers/prompts/feature-systems-thinking.md
+++ b/developers/prompts/feature-systems-thinking.md
@@ -17,8 +17,9 @@ Approach this like a systems thinker.
 6. Compare tradeoffs
 7. Choose best approach
 8. Give step-by-step execution
-9. Highlight failure points
-10. Create one new markdown proposal under docs/proposals whose body includes, in this order: (a) a section that summarises steps 1-9 in the file itself, and (b) post-v1 improvements. Use subfolder xip/ for app-wide or cross-cutting work, ieip/ for image editor, veip/ for video editor. Pick the next free XIP#### / IEIP#### / VEIP#### ID (match existing numbering in that folder), name the file PREFIX####-descriptive-slug.md using the correct prefix for that subfolder and the same slug style as sibling files, and follow the proposal structure and naming rules in .ai/skills/write-xip/SKILL.md plus the style of existing proposals in that subfolder.
+9. Use git in stages while carrying out step 8: commit whenever a logical chunk of the work is complete (for example a sub-problem, phase, or self-contained change that builds and tests cleanly), not only at the very end. Prefer several focused commits over one large catch-all commit unless the work is genuinely atomic. Follow AGENTS.md for commit message format.
+10. Highlight failure points
+11. Create one new markdown proposal under docs/proposals whose body includes, in this order: (a) a section that summarises steps 1-10 in the file itself, and (b) post-v1 improvements. Use subfolder xip/ for app-wide or cross-cutting work, ieip/ for image editor, veip/ for video editor. Pick the next free XIP#### / IEIP#### / VEIP#### ID (match existing numbering in that folder), name the file PREFIX####-descriptive-slug.md using the correct prefix for that subfolder and the same slug style as sibling files, and follow the proposal structure and naming rules in .ai/skills/write-xip/SKILL.md plus the style of existing proposals in that subfolder.
 
 Problem:
 [paste problem description here]

--- a/docs/proposals/xip/XIP0057-send-to-post-v1-defaults-and-folder-policies.md
+++ b/docs/proposals/xip/XIP0057-send-to-post-v1-defaults-and-folder-policies.md
@@ -1,0 +1,129 @@
+# XIP0057 Send-to Post-v1 Defaults and Folder Policies
+**Status**: PROPOSED
+**Priority**: Medium
+**Audit date**: 2026-03-27
+**Related**: XIP0055
+
+---
+
+## Problem Statement
+XIP0055 introduces the critical v1 correction: Send-to no longer implies upload, and users must choose an explicit action before XerahS starts work.
+
+That fixes the main UX failure, but it intentionally leaves three second-order problems unsolved:
+
+1. Users who always take the same action still pay the prompt cost on every Send-to invocation.
+2. Folder-containing Send-to selections still need a more explicit, user-visible policy for how non-index actions treat directories.
+3. Multi-item image actions can become mechanically correct but operationally noisy when they open or pin many items at once.
+
+These are good v1 tradeoffs because they keep the first release scoped and safe. They should still be addressed as a follow-up so Send-to grows into a stable, configurable intake surface instead of remaining a one-off prompt.
+
+---
+
+## Goals
+1. Add an explicit, reversible way to remember Send-to choices without hiding intent.
+2. Make folder handling transparent for `Upload now` and `Open in Upload Content`.
+3. Improve batch ergonomics for image-editor and pin-to-screen Send-to actions.
+4. Preserve the distinction between `Send to XerahS` and `Upload with XerahS`.
+
+## Non-Goals
+- Replacing the Send-to prompt with silent behavior by default.
+- Reworking the entire upload pipeline or workflow catalog.
+- Changing watch-folder, clipboard, or shell context-menu semantics outside Send-to.
+
+---
+
+## Proposed Design
+### 1) Remembered Send-to choice with explicit scope
+Add an optional `Remember this choice` control to the Send-to prompt introduced by XIP0055.
+
+Remembered choices should be stored with an explicit scope so the behavior remains understandable:
+
+- `All files`
+- `All folders`
+- `Mixed files and folders`
+- `Image-only files`
+
+Rules:
+- No remembered choice is applied unless the current selection matches the stored scope.
+- The UI must always surface where the remembered rule came from and provide a one-click reset path.
+- `Upload with XerahS` remains unaffected; remembered Send-to choices apply only to `--send-to` invocations.
+
+Settings UX:
+- Add a small Send-to section under integration/task settings that lists current remembered rules.
+- Provide `Clear remembered Send-to choices`.
+
+### 2) Explicit folder policy for non-index actions
+V1 can safely expand folders conservatively or skip them, but post-v1 should make the rule explicit and configurable.
+
+Add a Send-to folder policy for actions that are not `Index folder`:
+
+- `Do not expand folders`
+- `Include top-level files`
+- `Include files recursively`
+
+The prompt should show a short scope summary when folders are present, for example:
+
+- `Upload now will include 12 top-level files from 3 folders.`
+- `Open in Upload Content will ignore folders with the current policy.`
+
+This removes ambiguity for mixed selections and makes logs match what users actually approved.
+
+### 3) Batch execution policy for image actions
+When Send-to receives many image files, `Open in Image Editor` and `Pin to Screen` need pacing and visibility.
+
+Add a batch execution policy:
+
+- `Open all immediately`
+- `Open sequentially`
+- `Confirm before opening more than N items`
+
+For pin-to-screen batches:
+- show a completion toast or summary with the number of successfully pinned images
+- surface skipped or failed files once, instead of one failure per file when possible
+
+### 4) Prompt summary and diagnostics hardening
+Extend Send-to diagnostics so one batch decision can always be reconstructed from the log:
+
+- remembered rule used or not used
+- folder policy used
+- number of file items resolved from folders
+- number of editor/pin actions started, skipped, or failed
+
+---
+
+## Acceptance Criteria
+1. Users can optionally remember a Send-to choice and clear it later.
+2. Remembered Send-to choices are scoped and never affect `Upload with XerahS`.
+3. Folder-containing Send-to selections show an explicit folder policy for non-index actions.
+4. Batch image actions offer a predictable execution policy and avoid uncontrolled window bursts.
+5. Logs clearly show the rule and folder policy used for each Send-to batch.
+
+---
+
+## Suggested Tests
+1. Remembered choice applies only when the incoming selection matches the stored scope.
+2. Clearing remembered Send-to choices removes all automatic routing.
+3. Folder policy `Do not expand folders` results in zero folder-derived upload-content or upload items.
+4. Folder policy `Include top-level files` excludes nested files.
+5. Folder policy `Include files recursively` includes nested files and logs the resolved count.
+6. Batch execution policy respects the configured threshold before opening many editor windows.
+
+---
+
+## Key Files Expected to Change / Be Added
+1. `src/desktop/app/XerahS.UI/Views/SendToPromptWindow.axaml`
+2. `src/desktop/app/XerahS.UI/ViewModels/SendToPromptViewModel.cs`
+3. `src/desktop/app/XerahS.UI/Services/AvaloniaUIService.cs`
+4. `src/desktop/app/XerahS.App/Program.cs`
+5. `src/desktop/app/XerahS.App/SendToIntegrationCoordinator.cs`
+6. `src/desktop/core/XerahS.Core/SendTo/*`
+7. `src/platform/XerahS.Platform.Abstractions/IUIService.cs`
+8. `src/desktop/app/XerahS.UI/Views/ApplicationSettingsView.axaml`
+
+---
+
+## Verification Commands
+```powershell
+dotnet build src/desktop/app/XerahS.sln -m:1
+dotnet test tests/XerahS.Tests/XerahS.Tests.csproj -m:1
+```

--- a/docs/proposals/xip/XIP0057-send-to-post-v1-defaults-and-folder-policies.md
+++ b/docs/proposals/xip/XIP0057-send-to-post-v1-defaults-and-folder-policies.md
@@ -9,11 +9,12 @@
 ## Problem Statement
 XIP0055 introduces the critical v1 correction: Send-to no longer implies upload, and users must choose an explicit action before XerahS starts work.
 
-That fixes the main UX failure, but it intentionally leaves three second-order problems unsolved:
+That fixes the main UX failure, but it intentionally leaves four second-order problems unsolved:
 
 1. Users who always take the same action still pay the prompt cost on every Send-to invocation.
 2. Folder-containing Send-to selections still need a more explicit, user-visible policy for how non-index actions treat directories.
-3. Multi-item image actions can become mechanically correct but operationally noisy when they open or pin many items at once.
+3. Upload-capable Send-to actions can bypass normal XerahS file naming behavior and leak source/provider placeholder names into the final URL, such as `_pb.jpg`, instead of using the configured name pattern.
+4. Multi-item image actions can become mechanically correct but operationally noisy when they open or pin many items at once.
 
 These are good v1 tradeoffs because they keep the first release scoped and safe. They should still be addressed as a follow-up so Send-to grows into a stable, configurable intake surface instead of remaining a one-off prompt.
 
@@ -22,8 +23,9 @@ These are good v1 tradeoffs because they keep the first release scoped and safe.
 ## Goals
 1. Add an explicit, reversible way to remember Send-to choices without hiding intent.
 2. Make folder handling transparent for `Upload now` and `Open in Upload Content`.
-3. Improve batch ergonomics for image-editor and pin-to-screen Send-to actions.
-4. Preserve the distinction between `Send to XerahS` and `Upload with XerahS`.
+3. Preserve XerahS file naming parity for Send-to actions that result in upload.
+4. Improve batch ergonomics for image-editor and pin-to-screen Send-to actions.
+5. Preserve the distinction between `Send to XerahS` and `Upload with XerahS`.
 
 ## Non-Goals
 - Replacing the Send-to prompt with silent behavior by default.
@@ -68,7 +70,29 @@ The prompt should show a short scope summary when folders are present, for examp
 
 This removes ambiguity for mixed selections and makes logs match what users actually approved.
 
-### 3) Batch execution policy for image actions
+### 3) Upload naming parity with standard workflows
+Any Send-to action that results in upload should resolve the upload name through the same naming policy used by normal XerahS uploads.
+
+Observed symptom:
+
+- the uploaded asset can retain a placeholder or source-derived name such as `_pb.jpg`
+- the final URL therefore no longer reflects the configured XerahS name pattern
+
+Post-v1 design rules:
+
+- `Upload now` and `Open in Upload Content` must converge on the same naming resolution path before upload begins.
+- If the source item does not already have an XerahS-generated upload name, XerahS should materialize a staged file or staged upload item whose name is derived from the active task settings name pattern.
+- Generated names must respect the same collision handling rules used by normal XerahS uploads.
+- Folder expansion policy and naming policy must compose cleanly: each resolved file gets its own generated upload name after folder expansion, not before.
+- The Upload Content UI should surface the resolved upload name when feasible so users can verify what will be sent.
+
+Diagnostics:
+
+- log the original source path
+- log whether a staging/materialization step occurred
+- log the resolved upload name used for the outgoing upload
+
+### 4) Batch execution policy for image actions
 When Send-to receives many image files, `Open in Image Editor` and `Pin to Screen` need pacing and visibility.
 
 Add a batch execution policy:
@@ -81,12 +105,14 @@ For pin-to-screen batches:
 - show a completion toast or summary with the number of successfully pinned images
 - surface skipped or failed files once, instead of one failure per file when possible
 
-### 4) Prompt summary and diagnostics hardening
+### 5) Prompt summary and diagnostics hardening
 Extend Send-to diagnostics so one batch decision can always be reconstructed from the log:
 
 - remembered rule used or not used
 - folder policy used
+- naming policy used
 - number of file items resolved from folders
+- number of staged file names generated
 - number of editor/pin actions started, skipped, or failed
 
 ---
@@ -95,8 +121,10 @@ Extend Send-to diagnostics so one batch decision can always be reconstructed fro
 1. Users can optionally remember a Send-to choice and clear it later.
 2. Remembered Send-to choices are scoped and never affect `Upload with XerahS`.
 3. Folder-containing Send-to selections show an explicit folder policy for non-index actions.
-4. Batch image actions offer a predictable execution policy and avoid uncontrolled window bursts.
-5. Logs clearly show the rule and folder policy used for each Send-to batch.
+4. Send-to uploads use the same effective naming policy as equivalent non-Send-to uploads.
+5. `Upload now` and `Open in Upload Content` do not diverge in generated upload names for the same input and task settings.
+6. Batch image actions offer a predictable execution policy and avoid uncontrolled window bursts.
+7. Logs clearly show the rule, folder policy, and naming policy used for each Send-to batch.
 
 ---
 
@@ -106,7 +134,10 @@ Extend Send-to diagnostics so one batch decision can always be reconstructed fro
 3. Folder policy `Do not expand folders` results in zero folder-derived upload-content or upload items.
 4. Folder policy `Include top-level files` excludes nested files.
 5. Folder policy `Include files recursively` includes nested files and logs the resolved count.
-6. Batch execution policy respects the configured threshold before opening many editor windows.
+6. Send-to `Upload now` applies the configured XerahS name pattern before upload instead of leaking the source/provider placeholder name.
+7. Send-to `Open in Upload Content` resolves the same upload name that `Upload now` would produce for the same input.
+8. Generated Send-to upload names remain collision-safe when multiple files resolve from folders.
+9. Batch execution policy respects the configured threshold before opening many editor windows.
 
 ---
 
@@ -118,12 +149,15 @@ Extend Send-to diagnostics so one batch decision can always be reconstructed fro
 5. `src/desktop/app/XerahS.App/SendToIntegrationCoordinator.cs`
 6. `src/desktop/core/XerahS.Core/SendTo/*`
 7. `src/platform/XerahS.Platform.Abstractions/IUIService.cs`
-8. `src/desktop/app/XerahS.UI/Views/ApplicationSettingsView.axaml`
+8. `src/desktop/app/XerahS.UI/Services/UploadContentToolService.cs`
+9. `src/desktop/app/XerahS.UI/ViewModels/UploadContentViewModel.cs`
+10. `src/desktop/core/XerahS.Core/Tasks/*`
+11. `src/desktop/app/XerahS.UI/Views/ApplicationSettingsView.axaml`
 
 ---
 
 ## Verification Commands
 ```powershell
-dotnet build src/desktop/app/XerahS.sln -m:1
+dotnet build src/desktop/XerahS.sln -m:1
 dotnet test tests/XerahS.Tests/XerahS.Tests.csproj -m:1
 ```

--- a/src/desktop/app/XerahS.App/Program.cs
+++ b/src/desktop/app/XerahS.App/Program.cs
@@ -28,6 +28,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using XerahS.Core;
 using XerahS.Core.Managers;
+using XerahS.Core.SendTo;
 using XerahS.Platform.Abstractions;
 using XerahS.Services.Abstractions;
 
@@ -42,6 +43,13 @@ namespace XerahS.App
         private const string PipeName = "XerahS-Pipe-1F42DA49-7B2A-4E6F-8A3C-D56F09E0C481";
         private const string SendToFlag = "--send-to";
         private const string LegacyInstallPluginFlag = "-InstallPlugin";
+
+        private sealed class IncomingPathSet
+        {
+            public List<string> Files { get; } = [];
+
+            public List<string> Folders { get; } = [];
+        }
 
         [STAThread]
         public static void Main(string[] args)
@@ -715,26 +723,59 @@ namespace XerahS.App
                 return;
             }
 
-            List<string> files = ExtractSendToFilePaths(args);
-            if (files.Count == 0)
+            bool isSendToInvocation = IsSendToInvocation(args);
+            IncomingPathSet pathSet = ExtractIncomingPaths(args, includeDirectories: isSendToInvocation);
+
+            if (pathSet.Files.Count == 0 && pathSet.Folders.Count == 0)
             {
                 XerahS.Common.DebugHelper.WriteLine(
-                    $"Shell integration ({source}): No valid file paths found in arguments.");
+                    isSendToInvocation
+                        ? $"Shell integration ({source}): No valid file or folder paths found in Send-to arguments."
+                        : $"Shell integration ({source}): No valid file paths found in arguments.");
+                return;
+            }
+
+            if (isSendToInvocation)
+            {
+                SendToSelection selection = SendToSelectionClassifier.Create(pathSet.Files, pathSet.Folders);
+
+                XerahS.Common.DebugHelper.WriteLine(
+                    $"Shell integration ({source}): Scheduling Send-to prompt for {selection.ItemCount} item(s).");
+
+                _ = Task.Run(() => HandleSendToInvocationAsync(selection, source));
                 return;
             }
 
             XerahS.Common.DebugHelper.WriteLine(
-                $"Shell integration ({source}): Scheduling upload for {files.Count} file(s).");
-            _ = Task.Run(() => UploadFilesFromIntegrationAsync(files));
+                $"Shell integration ({source}): Scheduling upload for {pathSet.Files.Count} file(s).");
+            _ = Task.Run(() => UploadFilesFromIntegrationAsync(pathSet.Files));
         }
 
-        private static List<string> ExtractSendToFilePaths(IEnumerable<string> args)
+        private static bool IsSendToInvocation(IEnumerable<string> args)
+        {
+            foreach (string rawArg in args)
+            {
+                if (string.IsNullOrWhiteSpace(rawArg))
+                {
+                    continue;
+                }
+
+                if (rawArg.Trim().Equals(SendToFlag, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static IncomingPathSet ExtractIncomingPaths(IEnumerable<string> args, bool includeDirectories)
         {
             var comparer = OperatingSystem.IsWindows()
                 ? StringComparer.OrdinalIgnoreCase
                 : StringComparer.Ordinal;
             var uniquePaths = new HashSet<string>(comparer);
-            var files = new List<string>();
+            IncomingPathSet paths = new();
 
             bool skipNextAsPluginPath = false;
 
@@ -769,18 +810,20 @@ namespace XerahS.App
                     continue;
                 }
 
-                if (!File.Exists(normalizedPath))
+                if (File.Exists(normalizedPath))
                 {
-                    continue;
+                    if (uniquePaths.Add(normalizedPath))
+                    {
+                        paths.Files.Add(normalizedPath);
+                    }
                 }
-
-                if (uniquePaths.Add(normalizedPath))
+                else if (includeDirectories && Directory.Exists(normalizedPath) && uniquePaths.Add(normalizedPath))
                 {
-                    files.Add(normalizedPath);
+                    paths.Folders.Add(normalizedPath);
                 }
             }
 
-            return files;
+            return paths;
         }
 
         private static bool TryNormalizeLocalPath(string input, out string normalizedPath)
@@ -836,6 +879,30 @@ namespace XerahS.App
             catch (Exception ex)
             {
                 XerahS.Common.DebugHelper.WriteException(ex, "Shell integration: Failed to upload incoming files.");
+            }
+        }
+
+        private static async Task HandleSendToInvocationAsync(SendToSelection selection, string source)
+        {
+            try
+            {
+                var taskManager = PlatformServices.RootProvider?.GetService<ITaskManager>();
+                if (taskManager == null)
+                {
+                    XerahS.Common.DebugHelper.WriteLine("Shell integration: Task manager unavailable for Send-to items.");
+                    return;
+                }
+
+                SendToIntegrationCoordinator coordinator = new(
+                    PlatformServices.UI,
+                    taskManager,
+                    CreateFileUploadTaskSettings);
+
+                await coordinator.HandleAsync(selection, source);
+            }
+            catch (Exception ex)
+            {
+                XerahS.Common.DebugHelper.WriteException(ex, "Shell integration: Failed to process Send-to items.");
             }
         }
 

--- a/src/desktop/app/XerahS.App/SendToIntegrationCoordinator.cs
+++ b/src/desktop/app/XerahS.App/SendToIntegrationCoordinator.cs
@@ -1,0 +1,185 @@
+#region License Information (GPL v3)
+
+/*
+    XerahS - The Avalonia UI implementation of ShareX
+    Copyright (c) 2007-2026 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using XerahS.Common;
+using XerahS.Core;
+using XerahS.Platform.Abstractions;
+using XerahS.Services.Abstractions;
+
+namespace XerahS.App
+{
+    public sealed class SendToIntegrationCoordinator
+    {
+        private readonly IUIService _uiService;
+        private readonly ITaskManager _taskManager;
+        private readonly Func<TaskSettings> _createUploadTaskSettings;
+
+        public SendToIntegrationCoordinator(
+            IUIService uiService,
+            ITaskManager taskManager,
+            Func<TaskSettings> createUploadTaskSettings)
+        {
+            _uiService = uiService ?? throw new ArgumentNullException(nameof(uiService));
+            _taskManager = taskManager ?? throw new ArgumentNullException(nameof(taskManager));
+            _createUploadTaskSettings = createUploadTaskSettings ?? throw new ArgumentNullException(nameof(createUploadTaskSettings));
+        }
+
+        public async Task HandleAsync(SendToSelection selection, string source)
+        {
+            ArgumentNullException.ThrowIfNull(selection);
+
+            SendToPromptResult decision = await ResolveDecisionAsync(selection);
+            LogDecision(source, selection, decision);
+
+            switch (decision.Action)
+            {
+                case SendToAction.Cancel:
+                    DebugHelper.WriteLine($"Shell integration ({source}): Send-to cancelled; no task started.");
+                    return;
+
+                case SendToAction.UploadNow:
+                    DebugHelper.WriteLine($"Shell integration ({source}): Upload explicitly requested from Send-to.");
+                    await UploadSelectionAsync(selection, source);
+                    return;
+
+                default:
+                    DebugHelper.WriteLine(
+                        $"Shell integration ({source}): Upload skipped because Send-to action '{decision.Action}' was selected.");
+                    try
+                    {
+                        await _uiService.ExecuteSendToActionAsync(decision.Action, selection);
+                    }
+                    catch (Exception ex)
+                    {
+                        DebugHelper.WriteException(ex, $"Shell integration ({source}): Failed to execute Send-to action '{decision.Action}'.");
+                    }
+                    return;
+            }
+        }
+
+        public async Task UploadSelectionAsync(SendToSelection selection, string source)
+        {
+            ArgumentNullException.ThrowIfNull(selection);
+
+            List<string> uploadFiles = ResolveUploadFiles(selection);
+            if (uploadFiles.Count == 0)
+            {
+                DebugHelper.WriteLine(
+                    $"Shell integration ({source}): Send-to upload requested but no uploadable files were resolved.");
+                return;
+            }
+
+            foreach (string file in uploadFiles)
+            {
+                TaskSettings settings = _createUploadTaskSettings();
+                settings.Job = WorkflowType.FileUpload;
+                await _taskManager.StartFileTask(settings, file);
+            }
+        }
+
+        private async Task<SendToPromptResult> ResolveDecisionAsync(SendToSelection selection)
+        {
+            try
+            {
+                return await _uiService.ShowSendToPromptAsync(selection);
+            }
+            catch (Exception ex)
+            {
+                DebugHelper.WriteException(ex, "Shell integration: Send-to prompt failed; falling back to upload.");
+
+                return new SendToPromptResult
+                {
+                    Action = SendToAction.UploadNow,
+                    IsFallback = true,
+                    Reason = "Send-to prompt failed to open."
+                };
+            }
+        }
+
+        private static void LogDecision(string source, SendToSelection selection, SendToPromptResult decision)
+        {
+            string fallbackSuffix = decision.IsFallback
+                ? $", fallbackReason=\"{decision.Reason ?? "none"}\""
+                : string.Empty;
+
+            DebugHelper.WriteLine(
+                $"Shell integration ({source}): Send-to decision action={decision.Action}, source={(decision.IsFallback ? "fallback" : "prompt")}, " +
+                $"classification={selection.ClassificationLabel}, files={selection.FilePaths.Count}, folders={selection.FolderPaths.Count}, " +
+                $"allImages={selection.AllFilesAreImages}{fallbackSuffix}.");
+        }
+
+        private static List<string> ResolveUploadFiles(SendToSelection selection)
+        {
+            StringComparer comparer = OperatingSystem.IsWindows()
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal;
+
+            HashSet<string> seen = new(comparer);
+            List<string> uploadFiles = [];
+
+            foreach (string filePath in selection.FilePaths)
+            {
+                if (!string.IsNullOrWhiteSpace(filePath) && File.Exists(filePath) && seen.Add(filePath))
+                {
+                    uploadFiles.Add(filePath);
+                }
+            }
+
+            int expandedFolderFileCount = 0;
+
+            foreach (string folderPath in selection.FolderPaths)
+            {
+                if (string.IsNullOrWhiteSpace(folderPath) || !Directory.Exists(folderPath))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    foreach (string filePath in Directory.GetFiles(folderPath))
+                    {
+                        if (seen.Add(filePath))
+                        {
+                            uploadFiles.Add(filePath);
+                            expandedFolderFileCount++;
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    DebugHelper.WriteException(ex, $"Shell integration: Failed to enumerate folder '{folderPath}' for Send-to upload.");
+                }
+            }
+
+            if (selection.FolderPaths.Count > 0)
+            {
+                DebugHelper.WriteLine(
+                    $"Shell integration: Resolved {expandedFolderFileCount} top-level file(s) from {selection.FolderPaths.Count} folder Send-to item(s) for upload.");
+            }
+
+            return uploadFiles;
+        }
+    }
+}

--- a/src/desktop/app/XerahS.UI/Services/AvaloniaUIService.cs
+++ b/src/desktop/app/XerahS.UI/Services/AvaloniaUIService.cs
@@ -30,6 +30,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Threading;
 using Avalonia.Layout;
 using Avalonia.Media;
+using System.IO;
 using XerahS.Bootstrap;
 using XerahS.Common;
 using XerahS.Core;
@@ -471,6 +472,140 @@ namespace XerahS.UI.Services
                     window.Show();
                 }
             });
+        }
+
+        public async Task<SendToPromptResult> ShowSendToPromptAsync(SendToSelection selection)
+        {
+            return await Dispatcher.UIThread.InvokeAsync(async () =>
+            {
+                var viewModel = new SendToPromptViewModel(selection);
+                var window = new Views.SendToPromptWindow
+                {
+                    DataContext = viewModel
+                };
+
+                Window? owner = TryGetDialogOwner();
+                if (CanUseDialogOwner(owner))
+                {
+                    await window.ShowDialog(owner!);
+                }
+                else
+                {
+                    var closedTcs = new TaskCompletionSource<bool>();
+                    window.Closed += (_, _) => closedTcs.TrySetResult(true);
+                    window.Show();
+                    await closedTcs.Task;
+                }
+
+                return new SendToPromptResult
+                {
+                    Action = viewModel.SelectedAction
+                };
+            });
+        }
+
+        public async Task ExecuteSendToActionAsync(SendToAction action, SendToSelection selection)
+        {
+            if (action is SendToAction.Cancel or SendToAction.UploadNow)
+            {
+                return;
+            }
+
+            Window? owner = TryGetDialogOwner();
+
+            switch (action)
+            {
+                case SendToAction.OpenUploadContent:
+                    await UploadContentToolService.ShowSelectionAsync(selection.FilePaths, selection.FolderPaths, owner);
+                    break;
+
+                case SendToAction.OpenImageEditor:
+                    await OpenSelectedImagesInEditorAsync(selection);
+                    break;
+
+                case SendToAction.PinToScreen:
+                    await PinSelectedImagesAsync(selection);
+                    break;
+
+                case SendToAction.IndexFolders:
+                    await OpenSelectedFoldersInIndexFolderAsync(selection, owner);
+                    break;
+            }
+        }
+
+        private async Task OpenSelectedImagesInEditorAsync(SendToSelection selection)
+        {
+            if (!selection.CanOpenImageEditor)
+            {
+                return;
+            }
+
+            foreach (var filePath in selection.FilePaths ?? Array.Empty<string>())
+            {
+                if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath))
+                {
+                    continue;
+                }
+
+                using var bitmap = SkiaSharp.SKBitmap.Decode(filePath);
+                if (bitmap == null)
+                {
+                    continue;
+                }
+
+                await ShowEditorAsync(bitmap);
+            }
+        }
+
+        private static Task PinSelectedImagesAsync(SendToSelection selection)
+        {
+            if (!selection.CanPinToScreen)
+            {
+                return Task.CompletedTask;
+            }
+
+            return PinToScreenToolService.PinFilesAsync(selection.FilePaths);
+        }
+
+        private async Task OpenSelectedFoldersInIndexFolderAsync(SendToSelection selection, Window? owner)
+        {
+            if (!selection.CanIndexFolders)
+            {
+                return;
+            }
+
+            foreach (var folderPath in selection.FolderPaths ?? Array.Empty<string>())
+            {
+                if (string.IsNullOrWhiteSpace(folderPath) || !Directory.Exists(folderPath))
+                {
+                    continue;
+                }
+
+                await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    var viewModel = UiViewModelFactoryAccessor.GetRequired().CreateIndexFolderViewModel();
+                    viewModel.FolderPath = folderPath;
+
+                    var window = new Views.IndexFolderView
+                    {
+                        DataContext = viewModel
+                    };
+
+                    if (CanUseDialogOwner(owner))
+                    {
+                        window.Show(owner!);
+                    }
+                    else
+                    {
+                        window.Show();
+                    }
+
+                    if (viewModel.CanStartIndexing)
+                    {
+                        _ = viewModel.IndexFolderCommand.ExecuteAsync(null);
+                    }
+                });
+            }
         }
     }
 }

--- a/src/desktop/app/XerahS.UI/Services/PinToScreenToolService.cs
+++ b/src/desktop/app/XerahS.UI/Services/PinToScreenToolService.cs
@@ -64,6 +64,50 @@ public static class PinToScreenToolService
         }
     }
 
+    public static Task PinFilesAsync(IEnumerable<string>? filePaths)
+    {
+        int pinnedCount = 0;
+        int skippedCount = 0;
+
+        foreach (string filePath in filePaths ?? Enumerable.Empty<string>())
+        {
+            if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath))
+            {
+                skippedCount++;
+                continue;
+            }
+
+            try
+            {
+                var bitmap = SKBitmap.Decode(filePath);
+                if (bitmap == null)
+                {
+                    skippedCount++;
+                    continue;
+                }
+
+                PinToScreenManager.PinImage(bitmap, null, GetOptions());
+                pinnedCount++;
+            }
+            catch (Exception ex)
+            {
+                skippedCount++;
+                DebugHelper.WriteException(ex, $"PinToScreen: Failed to pin '{filePath}'.");
+            }
+        }
+
+        if (pinnedCount == 0)
+        {
+            ShowToast("Pin to Screen", "No compatible image files were available to pin.");
+        }
+        else if (skippedCount > 0)
+        {
+            ShowToast("Pin to Screen", $"Pinned {pinnedCount} image(s); skipped {skippedCount} item(s).");
+        }
+
+        return Task.CompletedTask;
+    }
+
     private static async Task PinToScreenAsync(Window? owner)
     {
         // Show startup dialog to let user choose source

--- a/src/desktop/app/XerahS.UI/Services/UploadContentToolService.cs
+++ b/src/desktop/app/XerahS.UI/Services/UploadContentToolService.cs
@@ -24,6 +24,8 @@
 #endregion License Information (GPL v3)
 
 using Avalonia.Controls;
+using Avalonia.Threading;
+using System.Linq;
 using XerahS.Common;
 using XerahS.Core;
 using XerahS.UI.Services;
@@ -42,17 +44,69 @@ public static class UploadContentToolService
     /// </param>
     public static Task HandleWorkflowAsync(WorkflowType job, Window? owner, bool background = false)
     {
-        ShowWindow(owner, background);
+        var window = ShowWindow(owner, background);
 
         if (job is WorkflowType.ClipboardUploadWithContentViewer or WorkflowType.ClipboardViewer)
         {
-            _window?.ViewModel?.LoadFromClipboardCommand.Execute(null);
+            window.ViewModel?.LoadFromClipboardCommand.Execute(null);
         }
 
         return Task.CompletedTask;
     }
 
-    private static void ShowWindow(Window? owner, bool background)
+    public static async Task ShowSelectionAsync(
+        IEnumerable<string>? filePaths,
+        IEnumerable<string>? folderPaths,
+        Window? owner)
+    {
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            var window = ShowWindow(owner, background: false);
+            var viewModel = window.ViewModel;
+            if (viewModel == null)
+            {
+                return;
+            }
+
+            UploadQueueItem? firstAddedItem = null;
+            int addedFileCount = 0;
+            int addedFolderCount = 0;
+
+            foreach (var filePath in filePaths ?? Enumerable.Empty<string>())
+            {
+                var addedItem = viewModel.AddFileItem(filePath);
+                if (addedItem != null)
+                {
+                    firstAddedItem ??= addedItem;
+                    addedFileCount++;
+                }
+            }
+
+            foreach (var folderPath in folderPaths ?? Enumerable.Empty<string>())
+            {
+                var addedItem = viewModel.AddFolderFiles(folderPath);
+                if (addedItem != null)
+                {
+                    firstAddedItem ??= addedItem;
+                }
+
+                if (!string.IsNullOrWhiteSpace(folderPath))
+                {
+                    addedFolderCount++;
+                }
+            }
+
+            if (firstAddedItem != null)
+            {
+                viewModel.SelectedItem = firstAddedItem;
+            }
+
+            DebugHelper.WriteLine(
+                $"UploadContent: Seeded Send-to selection with {addedFileCount} direct file(s) and {addedFolderCount} folder item(s).");
+        });
+    }
+
+    private static UploadContentWindow ShowWindow(Window? owner, bool background)
     {
         if (_window != null)
         {
@@ -70,7 +124,7 @@ public static class UploadContentToolService
                     _window.Activate();
                 }
 
-                return;
+                return _window;
             }
             catch
             {
@@ -102,5 +156,6 @@ public static class UploadContentToolService
         }
 
         DebugHelper.WriteLine($"UploadContent: Window shown (background={background}).");
+        return _window;
     }
 }

--- a/src/desktop/app/XerahS.UI/ViewModels/SendToPromptViewModel.cs
+++ b/src/desktop/app/XerahS.UI/ViewModels/SendToPromptViewModel.cs
@@ -1,0 +1,138 @@
+#region License Information (GPL v3)
+
+/*
+    XerahS - The Avalonia UI implementation of ShareX
+    Copyright (c) 2007-2026 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using CommunityToolkit.Mvvm.Input;
+using XerahS.Core;
+
+namespace XerahS.UI.ViewModels;
+
+public partial class SendToPromptViewModel : ViewModelBase
+{
+    private readonly SendToSelection _selection;
+
+    public SendToPromptViewModel(SendToSelection selection)
+    {
+        _selection = selection ?? throw new ArgumentNullException(nameof(selection));
+    }
+
+    public event Action? RequestClose;
+
+    public SendToAction SelectedAction { get; private set; } = SendToAction.Cancel;
+
+    public SendToPromptResult Result => new()
+    {
+        Action = SelectedAction
+    };
+
+    public string SelectionSummaryText => _selection.Kind switch
+    {
+        SendToSelectionKind.AllFiles => FormatCount(_selection.FilePaths.Count, "file"),
+        SendToSelectionKind.AllFolders => FormatCount(_selection.FolderPaths.Count, "folder"),
+        _ => $"{FormatCount(_selection.FilePaths.Count, "file")} and {FormatCount(_selection.FolderPaths.Count, "folder")}"
+    };
+
+    public string SelectionKindText => _selection.Kind switch
+    {
+        SendToSelectionKind.AllFiles when _selection.AllFilesAreImages => "Image files only",
+        SendToSelectionKind.AllFiles => "Files only",
+        SendToSelectionKind.AllFolders => "Folders only",
+        _ => "Mixed files and folders"
+    };
+
+    public string SelectionDetailsText => _selection.Kind switch
+    {
+        SendToSelectionKind.AllFiles when _selection.AllFilesAreImages =>
+            "All selected files are image-compatible, so upload, editor, pin, and queue actions are available.",
+        SendToSelectionKind.AllFiles =>
+            "Only file items were sent. Upload now and Upload Content will use those files directly.",
+        SendToSelectionKind.AllFolders =>
+            "Only folder items were sent. Upload and Upload Content use top-level files from those folders; Index folder preserves folder intent.",
+        _ =>
+            "Mixed Send-to batches keep file and folder behavior separate. Index folders only applies to folder items."
+    };
+
+    public string ActionScopeText => _selection.Kind switch
+    {
+        SendToSelectionKind.AllFiles when _selection.AllFilesAreImages =>
+            "This batch supports upload-first, queue-first, editor, and pin actions.",
+        SendToSelectionKind.AllFiles =>
+            "This batch supports upload-first and queue-first actions.",
+        SendToSelectionKind.AllFolders =>
+            "Upload actions use top-level files from each folder. Index preserves folder intent.",
+        _ =>
+            "Upload actions use files plus top-level folder files. Index applies only to folders."
+    };
+
+    public string UploadNowDescription => _selection.HasFolders
+        ? "Run the upload workflow for direct files and top-level files resolved from sent folders."
+        : "Run the current file upload workflow immediately.";
+
+    public string UploadContentDescription => _selection.HasFolders
+        ? "Open Upload Content with direct files and top-level files resolved from sent folders."
+        : "Open Upload Content and review the sent items before uploading.";
+
+    public string ImageEditorDescription => "Open each sent image in the image editor.";
+
+    public string PinToScreenDescription => "Pin each sent image directly to the desktop.";
+
+    public string IndexActionDescription => _selection.Kind == SendToSelectionKind.Mixed
+        ? "Run folder indexing for the sent folder items only."
+        : "Run the folder indexing workflow for the sent folders.";
+
+    public string IndexActionLabel => _selection.IndexActionLabel;
+
+    public bool CanOpenImageEditor => _selection.CanOpenImageEditor;
+
+    public bool CanPinToScreen => _selection.CanPinToScreen;
+
+    public bool CanIndexFolders => _selection.CanIndexFolders;
+
+    [RelayCommand]
+    private void UploadNow() => CloseWith(SendToAction.UploadNow);
+
+    [RelayCommand]
+    private void OpenUploadContent() => CloseWith(SendToAction.OpenUploadContent);
+
+    [RelayCommand]
+    private void OpenImageEditor() => CloseWith(SendToAction.OpenImageEditor);
+
+    [RelayCommand]
+    private void PinToScreen() => CloseWith(SendToAction.PinToScreen);
+
+    [RelayCommand]
+    private void IndexFolders() => CloseWith(SendToAction.IndexFolders);
+
+    [RelayCommand]
+    private void Cancel() => CloseWith(SendToAction.Cancel);
+
+    private void CloseWith(SendToAction action)
+    {
+        SelectedAction = action;
+        RequestClose?.Invoke();
+    }
+
+    private static string FormatCount(int count, string singular) =>
+        count == 1 ? $"1 {singular}" : $"{count} {singular}s";
+}

--- a/src/desktop/app/XerahS.UI/ViewModels/UploadContentViewModel.cs
+++ b/src/desktop/app/XerahS.UI/ViewModels/UploadContentViewModel.cs
@@ -304,9 +304,12 @@ public partial class UploadContentViewModel : ViewModelBase, IDisposable
         return item;
     }
 
-    public void AddFolderFiles(string folderPath)
+    public UploadQueueItem? AddFolderFiles(string folderPath)
     {
-        if (string.IsNullOrWhiteSpace(folderPath) || !Directory.Exists(folderPath)) return;
+        if (string.IsNullOrWhiteSpace(folderPath) || !Directory.Exists(folderPath))
+        {
+            return null;
+        }
 
         var files = Directory.GetFiles(folderPath);
         UploadQueueItem? firstAddedItem = null;
@@ -325,6 +328,7 @@ public partial class UploadContentViewModel : ViewModelBase, IDisposable
         }
 
         DebugHelper.WriteLine($"UploadContent: Added {files.Length} files from folder '{folderPath}'.");
+        return firstAddedItem;
     }
 
     public void AddTextItem(string text)

--- a/src/desktop/app/XerahS.UI/Views/SendToPromptWindow.axaml
+++ b/src/desktop/app/XerahS.UI/Views/SendToPromptWindow.axaml
@@ -1,0 +1,227 @@
+<ui:SurfaceWindow xmlns="https://github.com/avaloniaui"
+                  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                  xmlns:ui="using:XerahS.UI.Views"
+                  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                  xmlns:vm="using:XerahS.UI.ViewModels"
+                  mc:Ignorable="d"
+                  x:Class="XerahS.UI.Views.SendToPromptWindow"
+                  x:DataType="vm:SendToPromptViewModel"
+                  x:CompileBindings="True"
+                  Title="How should XerahS handle sent files?"
+                  Icon="/Assets/Logo.ico"
+                  Width="{DynamicResource WindowWidth}"
+                  Height="{DynamicResource WindowHeight}"
+                  MinWidth="{DynamicResource WindowMinWidth}"
+                  MinHeight="{DynamicResource WindowMinHeight}"
+                  WindowStartupLocation="CenterOwner">
+
+  <Window.Resources>
+    <x:Double x:Key="WindowWidth">920</x:Double>
+    <x:Double x:Key="WindowHeight">620</x:Double>
+    <x:Double x:Key="WindowMinWidth">760</x:Double>
+    <x:Double x:Key="WindowMinHeight">520</x:Double>
+
+    <x:Double x:Key="SpaceXS">4</x:Double>
+    <x:Double x:Key="SpaceS">8</x:Double>
+    <x:Double x:Key="SpaceM">12</x:Double>
+    <x:Double x:Key="SpaceL">16</x:Double>
+    <x:Double x:Key="SpaceXL">24</x:Double>
+
+    <x:Double x:Key="FontTitle">22</x:Double>
+    <x:Double x:Key="FontSection">16</x:Double>
+    <x:Double x:Key="FontBody">13</x:Double>
+    <x:Double x:Key="FontCaption">12</x:Double>
+
+    <x:Double x:Key="ControlHeight">40</x:Double>
+    <x:Double x:Key="ButtonMinWidth">150</x:Double>
+
+    <Thickness x:Key="PagePadding">24</Thickness>
+    <Thickness x:Key="CardPadding">16</Thickness>
+    <Thickness x:Key="CardPaddingCompact">12</Thickness>
+    <Thickness x:Key="ButtonPadding">16,8</Thickness>
+    <Thickness x:Key="BorderThin">1</Thickness>
+
+    <CornerRadius x:Key="CornerMd">8</CornerRadius>
+    <CornerRadius x:Key="CornerLg">12</CornerRadius>
+  </Window.Resources>
+
+  <Window.Styles>
+    <Style Selector="TextBlock">
+      <Setter Property="FontSize" Value="{StaticResource FontBody}"/>
+      <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}"/>
+    </Style>
+    <Style Selector="TextBlock.title">
+      <Setter Property="FontSize" Value="{StaticResource FontTitle}"/>
+      <Setter Property="FontWeight" Value="SemiBold"/>
+    </Style>
+    <Style Selector="TextBlock.section-header">
+      <Setter Property="FontSize" Value="{StaticResource FontSection}"/>
+      <Setter Property="FontWeight" Value="SemiBold"/>
+    </Style>
+    <Style Selector="TextBlock.caption">
+      <Setter Property="FontSize" Value="{StaticResource FontCaption}"/>
+      <Setter Property="TextWrapping" Value="Wrap"/>
+      <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}"/>
+    </Style>
+    <Style Selector="Border.card">
+      <Setter Property="Background" Value="{DynamicResource CardBackgroundFillColorDefaultBrush}"/>
+      <Setter Property="BorderBrush" Value="{DynamicResource CardStrokeColorDefaultBrush}"/>
+      <Setter Property="BorderThickness" Value="{StaticResource BorderThin}"/>
+      <Setter Property="CornerRadius" Value="{StaticResource CornerLg}"/>
+    </Style>
+    <Style Selector="Button">
+      <Setter Property="MinHeight" Value="{StaticResource ControlHeight}"/>
+      <Setter Property="MinWidth" Value="{StaticResource ButtonMinWidth}"/>
+      <Setter Property="Padding" Value="{StaticResource ButtonPadding}"/>
+      <Setter Property="CornerRadius" Value="{StaticResource CornerMd}"/>
+      <Setter Property="HorizontalAlignment" Value="Stretch"/>
+      <Setter Property="HorizontalContentAlignment" Value="Left"/>
+    </Style>
+  </Window.Styles>
+
+  <Border Background="{DynamicResource SolidBackgroundFillColorSecondaryBrush}"
+          Padding="{StaticResource PagePadding}">
+    <Grid RowDefinitions="Auto,*,Auto"
+          RowSpacing="{StaticResource SpaceXL}">
+      <Border Grid.Row="0"
+              Classes="card"
+              Padding="{StaticResource CardPadding}">
+        <Grid RowDefinitions="Auto,Auto"
+              RowSpacing="{StaticResource SpaceXS}">
+          <TextBlock Text="How should XerahS handle sent files?"
+                     Classes="title"
+                     AutomationProperties.Name="Send to title"/>
+          <TextBlock Grid.Row="1"
+                     Text="Choose the action before XerahS starts processing this Send-to batch."
+                     Classes="caption"
+                     AutomationProperties.Name="Send to description"/>
+        </Grid>
+      </Border>
+
+      <Grid Grid.Row="1"
+            ColumnDefinitions="1.05*,0.95*"
+            ColumnSpacing="{StaticResource SpaceL}">
+        <Border Classes="card"
+                Padding="{StaticResource CardPadding}">
+          <StackPanel Spacing="{StaticResource SpaceL}">
+            <StackPanel Spacing="{StaticResource SpaceXS}">
+              <TextBlock Text="Selection"
+                         Classes="section-header"
+                         AutomationProperties.Name="Selection heading"/>
+              <TextBlock Text="{Binding SelectionSummaryText}"
+                         FontWeight="SemiBold"
+                         AutomationProperties.Name="Selection summary"/>
+              <TextBlock Text="{Binding SelectionDetailsText}"
+                         Classes="caption"
+                         AutomationProperties.Name="Selection detail"/>
+            </StackPanel>
+
+            <Border Classes="card"
+                    Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
+                    Padding="{StaticResource CardPaddingCompact}">
+              <StackPanel Spacing="{StaticResource SpaceXS}">
+                <TextBlock Text="Classification"
+                           Classes="caption"
+                           AutomationProperties.Name="Selection kind label"/>
+                <TextBlock Text="{Binding SelectionKindText}"
+                           FontWeight="SemiBold"
+                           AutomationProperties.Name="Selection kind"/>
+                <TextBlock Text="{Binding ActionScopeText}"
+                           Classes="caption"
+                           AutomationProperties.Name="Selection action scope"/>
+              </StackPanel>
+            </Border>
+          </StackPanel>
+        </Border>
+
+        <Border Grid.Column="1"
+                Classes="card"
+                Padding="{StaticResource CardPadding}">
+          <ScrollViewer VerticalScrollBarVisibility="Auto"
+                        HorizontalScrollBarVisibility="Disabled">
+            <StackPanel Spacing="{StaticResource SpaceM}">
+              <StackPanel Spacing="{StaticResource SpaceXS}">
+                <TextBlock Text="Actions"
+                           Classes="section-header"
+                           AutomationProperties.Name="Actions heading"/>
+                <TextBlock Text="Primary actions are always available. Context-specific actions appear only when the sent items support them."
+                           Classes="caption"
+                           AutomationProperties.Name="Actions description"/>
+              </StackPanel>
+
+              <StackPanel Spacing="{StaticResource SpaceS}">
+                <StackPanel Spacing="{StaticResource SpaceXS}">
+                  <Button Content="Upload now"
+                          Classes="accent"
+                          Command="{Binding UploadNowCommand}"
+                          IsDefault="True"
+                          AutomationProperties.Name="Upload now"/>
+                  <TextBlock Text="{Binding UploadNowDescription}"
+                             Classes="caption"
+                             AutomationProperties.Name="Upload now description"/>
+                </StackPanel>
+
+                <StackPanel Spacing="{StaticResource SpaceXS}">
+                  <Button Content="Open in Upload Content"
+                          Command="{Binding OpenUploadContentCommand}"
+                          AutomationProperties.Name="Open in Upload Content"/>
+                  <TextBlock Text="{Binding UploadContentDescription}"
+                             Classes="caption"
+                             AutomationProperties.Name="Upload Content description"/>
+                </StackPanel>
+
+                <StackPanel Spacing="{StaticResource SpaceXS}"
+                            IsVisible="{Binding CanOpenImageEditor}">
+                  <Button Content="Open in Image Editor"
+                          Command="{Binding OpenImageEditorCommand}"
+                          AutomationProperties.Name="Open in Image Editor"/>
+                  <TextBlock Text="{Binding ImageEditorDescription}"
+                             Classes="caption"
+                             AutomationProperties.Name="Image Editor description"/>
+                </StackPanel>
+
+                <StackPanel Spacing="{StaticResource SpaceXS}"
+                            IsVisible="{Binding CanPinToScreen}">
+                  <Button Content="Pin to Screen"
+                          Command="{Binding PinToScreenCommand}"
+                          AutomationProperties.Name="Pin to Screen"/>
+                  <TextBlock Text="{Binding PinToScreenDescription}"
+                             Classes="caption"
+                             AutomationProperties.Name="Pin to Screen description"/>
+                </StackPanel>
+
+                <StackPanel Spacing="{StaticResource SpaceXS}"
+                            IsVisible="{Binding CanIndexFolders}">
+                  <Button Content="{Binding IndexActionLabel}"
+                          Command="{Binding IndexFoldersCommand}"
+                          AutomationProperties.Name="Index folders"/>
+                  <TextBlock Text="{Binding IndexActionDescription}"
+                             Classes="caption"
+                             AutomationProperties.Name="Index folders description"/>
+                </StackPanel>
+              </StackPanel>
+            </StackPanel>
+          </ScrollViewer>
+        </Border>
+      </Grid>
+
+      <Border Grid.Row="2"
+              Classes="card"
+              Padding="{StaticResource CardPaddingCompact}">
+        <Grid ColumnDefinitions="*,Auto"
+              ColumnSpacing="{StaticResource SpaceM}"
+              VerticalAlignment="Center">
+          <TextBlock Text="Closing the dialog cancels this Send-to request."
+                     Classes="caption"
+                     AutomationProperties.Name="Cancel hint"/>
+          <Button Grid.Column="1"
+                  Content="Cancel"
+                  Command="{Binding CancelCommand}"
+                  IsCancel="True"
+                  AutomationProperties.Name="Cancel"/>
+        </Grid>
+      </Border>
+    </Grid>
+  </Border>
+</ui:SurfaceWindow>

--- a/src/desktop/app/XerahS.UI/Views/SendToPromptWindow.axaml.cs
+++ b/src/desktop/app/XerahS.UI/Views/SendToPromptWindow.axaml.cs
@@ -1,0 +1,76 @@
+#region License Information (GPL v3)
+
+/*
+    XerahS - The Avalonia UI implementation of ShareX
+    Copyright (c) 2007-2026 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using Avalonia.Markup.Xaml;
+using XerahS.UI.ViewModels;
+
+namespace XerahS.UI.Views;
+
+public partial class SendToPromptWindow : SurfaceWindow
+{
+    private SendToPromptViewModel? _viewModel;
+
+    public SendToPromptWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    protected override void OnDataContextChanged(EventArgs e)
+    {
+        if (_viewModel != null)
+        {
+            _viewModel.RequestClose -= OnRequestClose;
+        }
+
+        base.OnDataContextChanged(e);
+
+        _viewModel = DataContext as SendToPromptViewModel;
+        if (_viewModel != null)
+        {
+            _viewModel.RequestClose += OnRequestClose;
+        }
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        if (_viewModel != null)
+        {
+            _viewModel.RequestClose -= OnRequestClose;
+            _viewModel = null;
+        }
+
+        base.OnClosed(e);
+    }
+
+    private void OnRequestClose()
+    {
+        Close();
+    }
+}

--- a/src/desktop/cli/XerahS.CLI/Services/HeadlessUIService.cs
+++ b/src/desktop/cli/XerahS.CLI/Services/HeadlessUIService.cs
@@ -165,6 +165,24 @@ namespace XerahS.CLI.Services
             return Task.CompletedTask;
         }
 
+        public Task<SendToPromptResult> ShowSendToPromptAsync(SendToSelection selection)
+        {
+            Console.WriteLine("[INFO] Send-to prompt not available in CLI mode. Falling back to upload.");
+
+            return Task.FromResult(new SendToPromptResult
+            {
+                Action = SendToAction.UploadNow,
+                IsFallback = true,
+                Reason = "CLI mode cannot display the Send-to prompt."
+            });
+        }
+
+        public Task ExecuteSendToActionAsync(SendToAction action, SendToSelection selection)
+        {
+            Console.WriteLine($"[INFO] Send-to action '{action}' is not available in CLI mode.");
+            return Task.CompletedTask;
+        }
+
         private static void LogVideoEditorFfmpegResolution(
             string? hostPath,
             string? detectedPath,

--- a/src/desktop/core/XerahS.Core/SendTo/SendToSelectionClassifier.cs
+++ b/src/desktop/core/XerahS.Core/SendTo/SendToSelectionClassifier.cs
@@ -1,0 +1,82 @@
+#region License Information (GPL v3)
+
+/*
+    XerahS - The Avalonia UI implementation of ShareX
+    Copyright (c) 2007-2026 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using XerahS.Common;
+
+namespace XerahS.Core.SendTo;
+
+public static class SendToSelectionClassifier
+{
+    public static SendToSelection Create(IEnumerable<string> filePaths, IEnumerable<string> folderPaths)
+    {
+        ArgumentNullException.ThrowIfNull(filePaths);
+        ArgumentNullException.ThrowIfNull(folderPaths);
+
+        string[] files = DistinctPaths(filePaths);
+        string[] folders = DistinctPaths(folderPaths);
+
+        SendToSelectionKind kind = folders.Length == 0
+            ? SendToSelectionKind.AllFiles
+            : files.Length == 0
+                ? SendToSelectionKind.AllFolders
+                : SendToSelectionKind.Mixed;
+
+        bool allFilesAreImages = files.Length > 0 && files.All(FileHelpers.IsImageFile);
+
+        return new SendToSelection
+        {
+            FilePaths = files,
+            FolderPaths = folders,
+            Kind = kind,
+            AllFilesAreImages = allFilesAreImages
+        };
+    }
+
+    private static string[] DistinctPaths(IEnumerable<string> paths)
+    {
+        StringComparer comparer = OperatingSystem.IsWindows()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+
+        List<string> orderedPaths = [];
+        HashSet<string> seen = new(comparer);
+
+        foreach (string rawPath in paths)
+        {
+            if (string.IsNullOrWhiteSpace(rawPath))
+            {
+                continue;
+            }
+
+            string normalizedPath = rawPath.Trim();
+            if (seen.Add(normalizedPath))
+            {
+                orderedPaths.Add(normalizedPath);
+            }
+        }
+
+        return orderedPaths.ToArray();
+    }
+}

--- a/src/desktop/tools/XerahS.WatchFolder.Daemon/Services/HeadlessUIService.cs
+++ b/src/desktop/tools/XerahS.WatchFolder.Daemon/Services/HeadlessUIService.cs
@@ -48,4 +48,16 @@ internal sealed class HeadlessUIService : IUIService
     }
 
     public Task ShowAfterUploadWindowAsync(AfterUploadWindowInfo info) => Task.CompletedTask;
+
+    public Task<SendToPromptResult> ShowSendToPromptAsync(SendToSelection selection)
+    {
+        return Task.FromResult(new SendToPromptResult
+        {
+            Action = SendToAction.UploadNow,
+            IsFallback = true,
+            Reason = "Headless UI service cannot display the Send-to prompt."
+        });
+    }
+
+    public Task ExecuteSendToActionAsync(SendToAction action, SendToSelection selection) => Task.CompletedTask;
 }

--- a/src/platform/XerahS.Platform.Abstractions/IUIService.cs
+++ b/src/platform/XerahS.Platform.Abstractions/IUIService.cs
@@ -68,5 +68,16 @@ namespace XerahS.Platform.Abstractions
         /// Shows the After Upload window with upload results and actions.
         /// </summary>
         Task ShowAfterUploadWindowAsync(AfterUploadWindowInfo info);
+
+        /// <summary>
+        /// Shows the Send-to action prompt and returns the chosen action.
+        /// Implementations may return a fallback upload decision when interactive UI is unavailable.
+        /// </summary>
+        Task<SendToPromptResult> ShowSendToPromptAsync(SendToSelection selection);
+
+        /// <summary>
+        /// Executes a non-upload Send-to action against the provided selection.
+        /// </summary>
+        Task ExecuteSendToActionAsync(SendToAction action, SendToSelection selection);
     }
 }

--- a/src/platform/XerahS.Platform.Abstractions/SendToModels.cs
+++ b/src/platform/XerahS.Platform.Abstractions/SendToModels.cs
@@ -1,0 +1,88 @@
+#region License Information (GPL v3)
+
+/*
+    XerahS - The Avalonia UI implementation of ShareX
+    Copyright (c) 2007-2026 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+namespace XerahS.Core;
+
+public enum SendToSelectionKind
+{
+    AllFiles,
+    AllFolders,
+    Mixed
+}
+
+public enum SendToAction
+{
+    UploadNow,
+    OpenUploadContent,
+    OpenImageEditor,
+    PinToScreen,
+    IndexFolders,
+    Cancel
+}
+
+public sealed class SendToSelection
+{
+    public IReadOnlyList<string> FilePaths { get; init; } = Array.Empty<string>();
+
+    public IReadOnlyList<string> FolderPaths { get; init; } = Array.Empty<string>();
+
+    public SendToSelectionKind Kind { get; init; }
+
+    public bool AllFilesAreImages { get; init; }
+
+    public int ItemCount => FilePaths.Count + FolderPaths.Count;
+
+    public bool HasFiles => FilePaths.Count > 0;
+
+    public bool HasFolders => FolderPaths.Count > 0;
+
+    public bool CanOpenImageEditor => HasFiles && !HasFolders && AllFilesAreImages;
+
+    public bool CanPinToScreen => CanOpenImageEditor;
+
+    public bool CanIndexFolders => HasFolders;
+
+    public string IndexActionLabel => Kind == SendToSelectionKind.Mixed
+        ? "Index folders only"
+        : FolderPaths.Count == 1
+            ? "Index folder"
+            : "Index folders";
+
+    public string ClassificationLabel => Kind switch
+    {
+        SendToSelectionKind.AllFiles => "allFiles",
+        SendToSelectionKind.AllFolders => "allFolders",
+        _ => "mixed"
+    };
+}
+
+public sealed class SendToPromptResult
+{
+    public SendToAction Action { get; init; } = SendToAction.Cancel;
+
+    public bool IsFallback { get; init; }
+
+    public string? Reason { get; init; }
+}

--- a/tests/XerahS.Tests/SendTo/SendToIntegrationCoordinatorTests.cs
+++ b/tests/XerahS.Tests/SendTo/SendToIntegrationCoordinatorTests.cs
@@ -1,0 +1,213 @@
+#region License Information (GPL v3)
+
+/*
+    XerahS - The Avalonia UI implementation of ShareX
+    Copyright (c) 2007-2026 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using NUnit.Framework;
+using SkiaSharp;
+using XerahS.App;
+using XerahS.Core;
+using XerahS.Platform.Abstractions;
+using XerahS.Services.Abstractions;
+
+namespace XerahS.Tests.SendTo;
+
+[TestFixture]
+public class SendToIntegrationCoordinatorTests
+{
+    [Test]
+    public async Task HandleAsync_WhenCancelled_DoesNothing()
+    {
+        FakeUiService uiService = new()
+        {
+            PromptResult = new SendToPromptResult { Action = SendToAction.Cancel }
+        };
+        FakeTaskManager taskManager = new();
+        SendToIntegrationCoordinator coordinator = CreateCoordinator(uiService, taskManager);
+        SendToSelection selection = new()
+        {
+            FilePaths = ["C:\\captures\\image.png"],
+            Kind = SendToSelectionKind.AllFiles,
+            AllFilesAreImages = true
+        };
+
+        await coordinator.HandleAsync(selection, "test");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(taskManager.StartFileTaskCalls, Is.EqualTo(0));
+            Assert.That(uiService.ExecutedActions, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task HandleAsync_WhenNonUploadActionSelected_DelegatesToUi()
+    {
+        FakeUiService uiService = new()
+        {
+            PromptResult = new SendToPromptResult { Action = SendToAction.OpenUploadContent }
+        };
+        FakeTaskManager taskManager = new();
+        SendToIntegrationCoordinator coordinator = CreateCoordinator(uiService, taskManager);
+        SendToSelection selection = new()
+        {
+            FilePaths = ["C:\\captures\\image.png"],
+            Kind = SendToSelectionKind.AllFiles,
+            AllFilesAreImages = true
+        };
+
+        await coordinator.HandleAsync(selection, "test");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(taskManager.StartFileTaskCalls, Is.EqualTo(0));
+            Assert.That(uiService.ExecutedActions, Is.EqualTo(new[] { SendToAction.OpenUploadContent }));
+        });
+    }
+
+    [Test]
+    public async Task HandleAsync_WhenUploadSelected_UploadsFilesAndTopLevelFolderFiles()
+    {
+        string rootPath = Path.Combine(Path.GetTempPath(), $"xerahs-sendto-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(rootPath);
+
+        try
+        {
+            string directFile = Path.Combine(rootPath, "direct.txt");
+            string folderPath = Path.Combine(rootPath, "folder");
+            string nestedFolderPath = Path.Combine(folderPath, "nested");
+            string folderFile = Path.Combine(folderPath, "from-folder.txt");
+            string nestedFile = Path.Combine(nestedFolderPath, "nested.txt");
+
+            Directory.CreateDirectory(folderPath);
+            Directory.CreateDirectory(nestedFolderPath);
+            await File.WriteAllTextAsync(directFile, "direct");
+            await File.WriteAllTextAsync(folderFile, "folder");
+            await File.WriteAllTextAsync(nestedFile, "nested");
+
+            FakeUiService uiService = new()
+            {
+                PromptResult = new SendToPromptResult { Action = SendToAction.UploadNow }
+            };
+            FakeTaskManager taskManager = new();
+            SendToIntegrationCoordinator coordinator = CreateCoordinator(uiService, taskManager);
+            SendToSelection selection = new()
+            {
+                FilePaths = [directFile],
+                FolderPaths = [folderPath],
+                Kind = SendToSelectionKind.Mixed
+            };
+
+            await coordinator.HandleAsync(selection, "test");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(taskManager.StartFileTaskCalls, Is.EqualTo(2));
+                Assert.That(taskManager.StartedFilePaths, Does.Contain(directFile));
+                Assert.That(taskManager.StartedFilePaths, Does.Contain(folderFile));
+                Assert.That(taskManager.StartedFilePaths, Does.Not.Contain(nestedFile));
+                Assert.That(taskManager.StartedJobs, Is.All.EqualTo(WorkflowType.FileUpload));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+
+    private static SendToIntegrationCoordinator CreateCoordinator(FakeUiService uiService, FakeTaskManager taskManager)
+    {
+        return new SendToIntegrationCoordinator(
+            uiService,
+            taskManager,
+            () => new TaskSettings());
+    }
+
+    private sealed class FakeTaskManager : ITaskManager
+    {
+        public int StartFileTaskCalls { get; private set; }
+
+        public List<string> StartedFilePaths { get; } = [];
+
+        public List<WorkflowType> StartedJobs { get; } = [];
+
+        public Task StartTask(object? taskSettings, SKBitmap? inputImage = null) => Task.CompletedTask;
+
+        public Task StartFileTask(object? taskSettings, string filePath)
+        {
+            StartFileTaskCalls++;
+            StartedFilePaths.Add(filePath);
+
+            if (taskSettings is TaskSettings settings)
+            {
+                StartedJobs.Add(settings.Job);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task StartImageUploadTask(object? taskSettings, SKBitmap image) => Task.CompletedTask;
+
+        public Task StartTextTask(object? taskSettings, string text) => Task.CompletedTask;
+
+        public void StopAllTasks()
+        {
+        }
+    }
+
+    private sealed class FakeUiService : IUIService
+    {
+        public SendToPromptResult PromptResult { get; set; } = new();
+
+        public List<SendToAction> ExecutedActions { get; } = [];
+
+        public Task HideMainWindowAsync() => Task.CompletedTask;
+
+        public Task RestoreMainWindowAsync() => Task.CompletedTask;
+
+        public Task<SKBitmap?> ShowEditorAsync(SKBitmap image, bool taskMode = false) => Task.FromResult<SKBitmap?>(image);
+
+        public Task<string?> ShowVideoEditorAsync(string videoPath, string? ffmpegPath) => Task.FromResult<string?>(null);
+
+        public Task<(AfterCaptureTasks Capture, AfterUploadTasks Upload, bool Cancel)> ShowAfterCaptureWindowAsync(
+            SKBitmap image,
+            AfterCaptureTasks afterCapture,
+            AfterUploadTasks afterUpload)
+        {
+            return Task.FromResult((afterCapture, afterUpload, false));
+        }
+
+        public Task ShowAfterUploadWindowAsync(AfterUploadWindowInfo info) => Task.CompletedTask;
+
+        public Task<SendToPromptResult> ShowSendToPromptAsync(SendToSelection selection) => Task.FromResult(PromptResult);
+
+        public Task ExecuteSendToActionAsync(SendToAction action, SendToSelection selection)
+        {
+            ExecutedActions.Add(action);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/XerahS.Tests/SendTo/SendToSelectionClassifierTests.cs
+++ b/tests/XerahS.Tests/SendTo/SendToSelectionClassifierTests.cs
@@ -1,0 +1,101 @@
+#region License Information (GPL v3)
+
+/*
+    XerahS - The Avalonia UI implementation of ShareX
+    Copyright (c) 2007-2026 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using NUnit.Framework;
+using XerahS.Core;
+using XerahS.Core.SendTo;
+
+namespace XerahS.Tests.SendTo;
+
+[TestFixture]
+public class SendToSelectionClassifierTests
+{
+    [Test]
+    public void Create_WithOnlyImageFiles_ClassifiesAsAllFiles()
+    {
+        SendToSelection selection = SendToSelectionClassifier.Create(
+            ["C:\\captures\\one.png", "C:\\captures\\two.jpg"],
+            []);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(selection.Kind, Is.EqualTo(SendToSelectionKind.AllFiles));
+            Assert.That(selection.AllFilesAreImages, Is.True);
+            Assert.That(selection.CanOpenImageEditor, Is.True);
+            Assert.That(selection.CanPinToScreen, Is.True);
+            Assert.That(selection.CanIndexFolders, Is.False);
+        });
+    }
+
+    [Test]
+    public void Create_WithOnlyFolders_ClassifiesAsAllFolders()
+    {
+        SendToSelection selection = SendToSelectionClassifier.Create(
+            [],
+            ["C:\\captures\\first", "C:\\captures\\second"]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(selection.Kind, Is.EqualTo(SendToSelectionKind.AllFolders));
+            Assert.That(selection.HasFolders, Is.True);
+            Assert.That(selection.HasFiles, Is.False);
+            Assert.That(selection.CanIndexFolders, Is.True);
+            Assert.That(selection.IndexActionLabel, Is.EqualTo("Index folders"));
+        });
+    }
+
+    [Test]
+    public void Create_WithFilesAndFolders_ClassifiesAsMixed()
+    {
+        SendToSelection selection = SendToSelectionClassifier.Create(
+            ["C:\\captures\\one.png"],
+            ["C:\\captures\\folder"]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(selection.Kind, Is.EqualTo(SendToSelectionKind.Mixed));
+            Assert.That(selection.CanIndexFolders, Is.True);
+            Assert.That(selection.IndexActionLabel, Is.EqualTo("Index folders only"));
+            Assert.That(selection.CanOpenImageEditor, Is.False);
+            Assert.That(selection.CanPinToScreen, Is.False);
+        });
+    }
+
+    [Test]
+    public void Create_WithNonImageFiles_DoesNotEnableImageActions()
+    {
+        SendToSelection selection = SendToSelectionClassifier.Create(
+            ["C:\\captures\\document.txt", "C:\\captures\\photo.png"],
+            []);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(selection.Kind, Is.EqualTo(SendToSelectionKind.AllFiles));
+            Assert.That(selection.AllFilesAreImages, Is.False);
+            Assert.That(selection.CanOpenImageEditor, Is.False);
+            Assert.That(selection.CanPinToScreen, Is.False);
+        });
+    }
+}

--- a/tests/XerahS.Tests/XerahS.Tests.csproj
+++ b/tests/XerahS.Tests/XerahS.Tests.csproj
@@ -28,6 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\desktop\app\XerahS.App\XerahS.App.csproj" />
     <ProjectReference Include="..\..\src\desktop\app\XerahS.Bootstrap\XerahS.Bootstrap.csproj" />
     <ProjectReference Include="..\..\src\desktop\core\XerahS.Core\XerahS.Core.csproj" />
     <ProjectReference Include="..\..\src\desktop\plugins\AmazonS3.Plugin\XerahS.AmazonS3.Plugin.csproj" />


### PR DESCRIPTION
This pull request introduces a new, robust architecture for handling Windows "Send-to" shell integration in XerahS, allowing both files and folders to be processed, and laying the groundwork for user-configurable Send-to behaviors. It adds a new proposal (XIP0057) describing post-v1 improvements, and implements a dedicated coordinator for Send-to actions, separating them from legacy upload-only flows. The changes ensure that Send-to invocations can trigger user prompts, support batch and folder policies, and provide clear logging and error handling.

**Send-to Shell Integration Improvements**

* Refactored argument handling in `Program.cs` to distinguish Send-to invocations, extract both files and folders, and route them through a new `SendToIntegrationCoordinator` for user-driven action selection. This enables future support for folder policies and batch actions. [[1]](diffhunk://#diff-b3ba1568c7fdcd9d55811af0f381d8926782682befd44b9523801dd91b57702aR31) [[2]](diffhunk://#diff-b3ba1568c7fdcd9d55811af0f381d8926782682befd44b9523801dd91b57702aR47-R53) [[3]](diffhunk://#diff-b3ba1568c7fdcd9d55811af0f381d8926782682befd44b9523801dd91b57702aL718-R778) [[4]](diffhunk://#diff-b3ba1568c7fdcd9d55811af0f381d8926782682befd44b9523801dd91b57702aL772-R826) [[5]](diffhunk://#diff-b3ba1568c7fdcd9d55811af0f381d8926782682befd44b9523801dd91b57702aR885-R908)
* Added `SendToIntegrationCoordinator` class to orchestrate Send-to prompts, user decisions, and execution of selected actions (including upload and other UI actions), with detailed logging and robust error handling.

**Documentation and Proposal Updates**

* Added `XIP0057-send-to-post-v1-defaults-and-folder-policies.md` proposal, outlining the future direction for Send-to defaults, folder handling, batch execution, and diagnostics, with acceptance criteria and affected files.
* Updated the "systems thinker" developer prompt to clarify the use of Git in stages and adjust the proposal-writing steps to reflect the new Send-to logic.

**Minor Codebase Updates**

* Added missing `using System.IO;` in `AvaloniaUIService.cs` to support new Send-to logic.

These changes collectively modernize the Send-to integration, making it more flexible and user-friendly, and set the stage for further improvements as described in XIP0057.