### PR TITLE
Codex/xip0072 recording fixes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.22.1</Version>
+    <Version>0.22.2</Version>
     <Product>XerahS</Product>
     <Authors>ShareX Team</Authors>
     <Company>ShareX Team</Company>

--- a/src/desktop/app/XerahS.RegionCapture/ScreenRecording/RecordingCodecSupportPolicy.cs
+++ b/src/desktop/app/XerahS.RegionCapture/ScreenRecording/RecordingCodecSupportPolicy.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+
+namespace XerahS.RegionCapture.ScreenRecording;
+
+/// <summary>
+/// Centralizes which screen-recording codecs are directly supported by the native backend
+/// versus requiring the FFmpeg fallback in the current build.
+/// </summary>
+public static class RecordingCodecSupportPolicy
+{
+    private static readonly IReadOnlyList<VideoCodec> NativeOnlyCodecs = new[]
+    {
+        VideoCodec.H264
+    };
+
+    private static readonly IReadOnlyList<VideoCodec> AllCodecs = new[]
+    {
+        VideoCodec.H264,
+        VideoCodec.HEVC,
+        VideoCodec.VP9,
+        VideoCodec.AV1
+    };
+
+    public static IReadOnlyList<VideoCodec> GetSelectableCodecs(bool ffmpegAvailable)
+    {
+        return GetSelectableCodecs(
+            ffmpegAvailable,
+            OperatingSystem.IsWindows(),
+            OperatingSystem.IsMacOS(),
+            OperatingSystem.IsLinux());
+    }
+
+    public static bool RequiresFfmpegFallback(VideoCodec codec)
+    {
+        return RequiresFfmpegFallback(
+            codec,
+            OperatingSystem.IsWindows(),
+            OperatingSystem.IsMacOS(),
+            OperatingSystem.IsLinux());
+    }
+
+    internal static IReadOnlyList<VideoCodec> GetSelectableCodecs(
+        bool ffmpegAvailable,
+        bool isWindows,
+        bool isMacOS,
+        bool isLinux)
+    {
+        if (isLinux)
+        {
+            return AllCodecs;
+        }
+
+        if ((isWindows || isMacOS) && ffmpegAvailable)
+        {
+            return AllCodecs;
+        }
+
+        return NativeOnlyCodecs;
+    }
+
+    internal static bool RequiresFfmpegFallback(
+        VideoCodec codec,
+        bool isWindows,
+        bool isMacOS,
+        bool isLinux)
+    {
+        if (codec == VideoCodec.H264)
+        {
+            return false;
+        }
+
+        if (isLinux)
+        {
+            return false;
+        }
+
+        return isWindows || isMacOS;
+    }
+}

--- a/src/desktop/app/XerahS.RegionCapture/ScreenRecording/RecordingModels.cs
+++ b/src/desktop/app/XerahS.RegionCapture/ScreenRecording/RecordingModels.cs
@@ -131,7 +131,11 @@ public readonly struct FrameData
     /// <summary>Pointer to raw pixel data</summary>
     public IntPtr DataPtr { get; init; }
 
-    /// <summary>Stride (bytes per row) of the frame</summary>
+    /// <summary>
+    /// Actual source stride in bytes per row.
+    /// This may be larger than <c>Width * bytesPerPixel</c> when the source surface includes padding.
+    /// Consumers must treat this as the row pitch used for address calculation, not as a guarantee of tight packing.
+    /// </summary>
     public int Stride { get; init; }
 
     /// <summary>Frame width in pixels</summary>

--- a/src/desktop/app/XerahS.RegionCapture/ScreenRecording/RegionCropper.cs
+++ b/src/desktop/app/XerahS.RegionCapture/ScreenRecording/RegionCropper.cs
@@ -66,6 +66,13 @@ public static class RegionCropper
             _ => throw new NotSupportedException($"Pixel format {sourceFrame.Format} not supported for cropping")
         };
 
+        if (sourceFrame.Stride < sourceFrame.Width * bytesPerPixel)
+        {
+            throw new ArgumentException(
+                $"Source frame stride ({sourceFrame.Stride}) is smaller than the required row width ({sourceFrame.Width * bytesPerPixel}).",
+                nameof(sourceFrame));
+        }
+
         // Calculate cropped frame properties
         int croppedStride = region.Width * bytesPerPixel;
         int croppedBufferSize = croppedStride * region.Height;

--- a/src/desktop/app/XerahS.UI/ViewModels/RecordingViewModel.cs
+++ b/src/desktop/app/XerahS.UI/ViewModels/RecordingViewModel.cs
@@ -23,6 +23,7 @@
 
 #endregion License Information (GPL v3)
 
+using System.IO;
 using System.Linq;
 using System.Timers;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -115,6 +116,9 @@ public partial class RecordingViewModel : ViewModelBase, IDisposable
     [ObservableProperty]
     private RecordingIntent _recordingIntent = RecordingIntent.Default;
 
+    [ObservableProperty]
+    private string _codecAvailabilityMessage = string.Empty;
+
     /// <summary>
     /// Available recording intents
     /// </summary>
@@ -123,13 +127,8 @@ public partial class RecordingViewModel : ViewModelBase, IDisposable
     /// <summary>
     /// Available codecs for selection
     /// </summary>
-    public List<VideoCodec> AvailableCodecs { get; } = new()
-    {
-        VideoCodec.H264,
-        VideoCodec.HEVC,
-        VideoCodec.VP9,
-        VideoCodec.AV1
-    };
+    public IReadOnlyList<VideoCodec> AvailableCodecs { get; } =
+        RecordingCodecSupportPolicy.GetSelectableCodecs(IsFfmpegAvailableForAdvancedCodecs());
 
     /// <summary>
     /// Available FPS options
@@ -154,11 +153,19 @@ public partial class RecordingViewModel : ViewModelBase, IDisposable
             // Simple platform check - detailed detection happens at runtime
             if (OperatingSystem.IsWindows() && Environment.OSVersion.Version.Build >= 17134)
             {
-                return "Modern recording available (Windows.Graphics.Capture + Media Foundation). Hardware encoding will be used if available.";
+                return IsFfmpegAvailableForAdvancedCodecs()
+                    ? "Windows uses native capture with Media Foundation for H.264. HEVC, VP9, and AV1 automatically switch to the FFmpeg backend in this build."
+                    : "Windows uses native capture with Media Foundation for H.264. Install FFmpeg to enable HEVC, VP9, and AV1 recording.";
             }
             else if (OperatingSystem.IsWindows())
             {
                 return "Using FFmpeg fallback for recording (requires Windows 10 1803+ for native recording).";
+            }
+            else if (OperatingSystem.IsMacOS())
+            {
+                return IsFfmpegAvailableForAdvancedCodecs()
+                    ? "macOS uses native recording for H.264. HEVC, VP9, and AV1 automatically switch to FFmpeg in this build."
+                    : "macOS native recording currently covers H.264 only. Install FFmpeg to enable HEVC, VP9, and AV1 recording.";
             }
             else
             {
@@ -202,11 +209,19 @@ public partial class RecordingViewModel : ViewModelBase, IDisposable
         {
             if (OperatingSystem.IsWindows() && Environment.OSVersion.Version.Build >= 17134)
             {
-                return "Note: Recording uses Windows.Graphics.Capture (Windows 10 1803+) with Media Foundation H.264 encoding.";
+                return IsFfmpegAvailableForAdvancedCodecs()
+                    ? "Note: H.264 records through Windows.Graphics.Capture + Media Foundation. HEVC, VP9, and AV1 are routed through FFmpeg automatically."
+                    : "Note: H.264 records through Windows.Graphics.Capture + Media Foundation. Install FFmpeg to unlock HEVC, VP9, and AV1.";
             }
             else if (OperatingSystem.IsWindows())
             {
                 return "Note: Recording uses FFmpeg for video encoding. Requires Windows 10 1803+ for native Windows.Graphics.Capture support.";
+            }
+            else if (OperatingSystem.IsMacOS())
+            {
+                return IsFfmpegAvailableForAdvancedCodecs()
+                    ? "Note: H.264 records natively. HEVC, VP9, and AV1 use FFmpeg on macOS in this build."
+                    : "Note: Install FFmpeg if you want HEVC, VP9, or AV1 on macOS.";
             }
             else
             {
@@ -513,6 +528,19 @@ public partial class RecordingViewModel : ViewModelBase, IDisposable
         _workflow.TaskSettings = _taskSettings;
 
         var recordingSettings = _taskSettings.CaptureSettings.ScreenRecordingSettings;
+        if (!AvailableCodecs.Contains(recordingSettings.Codec))
+        {
+            recordingSettings.Codec = VideoCodec.H264;
+            CodecAvailabilityMessage = "FFmpeg is not available, so advanced codecs are hidden and the recording codec was reset to H.264.";
+        }
+        else if ((OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()) && !IsFfmpegAvailableForAdvancedCodecs())
+        {
+            CodecAvailabilityMessage = "Install FFmpeg to enable HEVC, VP9, and AV1 on this platform.";
+        }
+        else
+        {
+            CodecAvailabilityMessage = string.Empty;
+        }
 
         // Seed UI from workflow settings
         Fps = recordingSettings.FPS;
@@ -576,6 +604,8 @@ public partial class RecordingViewModel : ViewModelBase, IDisposable
     {
         if (!_initialized) return;
         _taskSettings.CaptureSettings.ScreenRecordingSettings.Codec = value;
+        OnPropertyChanged(nameof(EncoderInfo));
+        OnPropertyChanged(nameof(UsageNotes));
     }
 
     partial void OnShowCursorChanged(bool value)
@@ -618,5 +648,16 @@ public partial class RecordingViewModel : ViewModelBase, IDisposable
         _screenRecordingCoordinator.ErrorOccurred -= OnErrorOccurred;
 
         GC.SuppressFinalize(this);
+    }
+
+    private static bool IsFfmpegAvailableForAdvancedCodecs()
+    {
+        if (OperatingSystem.IsLinux())
+        {
+            return true;
+        }
+
+        string ffmpegPath = PathsManager.GetFFmpegPath();
+        return !string.IsNullOrWhiteSpace(ffmpegPath) && File.Exists(ffmpegPath);
     }
 }

--- a/src/desktop/app/XerahS.UI/Views/RecordingView.axaml
+++ b/src/desktop/app/XerahS.UI/Views/RecordingView.axaml
@@ -130,6 +130,12 @@
 
                         </Grid>
 
+                        <TextBlock Text="{Binding CodecAvailabilityMessage}"
+                                   Theme="{StaticResource CaptionTextBlockStyle}"
+                                   Foreground="{DynamicResource SystemFillColorAttentionBrush}"
+                                   TextWrapping="Wrap"
+                                   IsVisible="{Binding CodecAvailabilityMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+
                         <TextBlock Text="Note: Higher bitrates and frame rates will result in larger file sizes. Hardware encoding may be used automatically if available. Audio capture requires FFmpeg and appropriate system audio devices."
                                    Theme="{StaticResource CaptionTextBlockStyle}"
                                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"

--- a/src/desktop/core/XerahS.Core/Managers/ScreenRecordingManager.cs
+++ b/src/desktop/core/XerahS.Core/Managers/ScreenRecordingManager.cs
@@ -471,6 +471,15 @@ public class ScreenRecordingManager : IScreenRecordingManager
             return true;
         }
 
+        if (settings is not null && RecordingCodecSupportPolicy.RequiresFfmpegFallback(settings.Codec))
+        {
+            TroubleshootingHelper.Log(
+                "ScreenRecorder",
+                "FALLBACK",
+                $"Codec {settings.Codec} requires FFmpeg because the native backend only supports H.264 in this build.");
+            return true;
+        }
+
         // Check if we have a native recording service factory (complete IRecordingService)
         if (ScreenRecorderService.NativeRecordingServiceFactory != null)
         {

--- a/src/platform/XerahS.Platform.Windows/Capture/BgraRowCopyHelper.cs
+++ b/src/platform/XerahS.Platform.Windows/Capture/BgraRowCopyHelper.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace XerahS.Platform.Windows.Capture;
+
+/// <summary>
+/// Copies tightly-addressable BGRA rows from a source buffer into a destination buffer.
+/// Handles padded source rows and optional vertical flipping without reading padding bytes.
+/// </summary>
+internal static class BgraRowCopyHelper
+{
+    public static unsafe void CopyRows(
+        IntPtr sourceBase,
+        int sourceStride,
+        IntPtr destinationBase,
+        int destinationStride,
+        int bytesPerRow,
+        int height,
+        bool flipVertically = false)
+    {
+        if (sourceBase == IntPtr.Zero) throw new ArgumentNullException(nameof(sourceBase));
+        if (destinationBase == IntPtr.Zero) throw new ArgumentNullException(nameof(destinationBase));
+        if (bytesPerRow <= 0) throw new ArgumentOutOfRangeException(nameof(bytesPerRow));
+        if (height < 0) throw new ArgumentOutOfRangeException(nameof(height));
+        if (height == 0) return;
+
+        int normalizedSourceStride = ValidateStride(sourceStride, bytesPerRow, nameof(sourceStride));
+        int normalizedDestinationStride = ValidateStride(destinationStride, bytesPerRow, nameof(destinationStride));
+
+        byte* srcTopRow = NormalizeTopRow((byte*)sourceBase.ToPointer(), sourceStride, height);
+        byte* dstTopRow = NormalizeTopRow((byte*)destinationBase.ToPointer(), destinationStride, height);
+
+        for (int y = 0; y < height; y++)
+        {
+            int sourceRowIndex = flipVertically ? height - 1 - y : y;
+            byte* srcRow = srcTopRow + (sourceRowIndex * normalizedSourceStride);
+            byte* dstRow = dstTopRow + (y * normalizedDestinationStride);
+            Buffer.MemoryCopy(srcRow, dstRow, normalizedDestinationStride, bytesPerRow);
+        }
+    }
+
+    private static unsafe byte* NormalizeTopRow(byte* basePointer, int stride, int height)
+    {
+        if (stride >= 0)
+        {
+            return basePointer;
+        }
+
+        return basePointer + ((height - 1) * stride);
+    }
+
+    private static int ValidateStride(int stride, int bytesPerRow, string paramName)
+    {
+        int absoluteStride = Math.Abs(stride);
+        if (absoluteStride < bytesPerRow)
+        {
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                $"{paramName} must be at least {bytesPerRow} bytes to copy one full pixel row.");
+        }
+
+        return absoluteStride;
+    }
+}

--- a/src/platform/XerahS.Platform.Windows/Capture/DxgiCaptureStrategy.cs
+++ b/src/platform/XerahS.Platform.Windows/Capture/DxgiCaptureStrategy.cs
@@ -29,6 +29,7 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using ShareX.Avalonia.Platform.Abstractions.Capture;
 using SkiaSharp;
+using XerahS.Platform.Windows.Capture;
 using Vortice.Direct3D;
 using Vortice.Direct3D11;
 using Vortice.DXGI;
@@ -239,21 +240,13 @@ internal sealed class DxgiCaptureStrategy : ICaptureStrategy
                 var info = bitmap.Info;
                 var rowBytes = info.RowBytes;
 
-                // Copy row by row (handles pitch difference)
-                unsafe
-                {
-                    var src = (byte*)mapped.DataPointer;
-                    var dst = (byte*)bitmap.GetPixels();
-
-                    for (int y = 0; y < captureRegion.Height; y++)
-                    {
-                        Buffer.MemoryCopy(
-                            src + y * mapped.RowPitch,
-                            dst + y * rowBytes,
-                            rowBytes,
-                            rowBytes);
-                    }
-                }
+                BgraRowCopyHelper.CopyRows(
+                    mapped.DataPointer,
+                    (int)mapped.RowPitch,
+                    bitmap.GetPixels(),
+                    rowBytes,
+                    captureRegion.Width * 4,
+                    captureRegion.Height);
 
                 return new CapturedBitmap(bitmap, captureRegion, monitor.ScaleFactor);
             }

--- a/src/platform/XerahS.Platform.Windows/Capture/GdiCaptureStrategy.cs
+++ b/src/platform/XerahS.Platform.Windows/Capture/GdiCaptureStrategy.cs
@@ -30,6 +30,7 @@ using System.Threading.Tasks;
 using ShareX.Avalonia.Platform.Abstractions.Capture;
 using SkiaSharp;
 using XerahS.Platform.Windows;
+using XerahS.Platform.Windows.Capture;
 
 namespace ShareX.Avalonia.Platform.Windows.Capture;
 
@@ -148,17 +149,13 @@ internal sealed class GdiCaptureStrategy : ICaptureStrategy
 
             unsafe
             {
-                var src = (byte*)bitmapData.Scan0;
-                var dst = (byte*)skBitmap.GetPixels();
-
-                for (int y = 0; y < gdiBitmap.Height; y++)
-                {
-                    Buffer.MemoryCopy(
-                        src + y * bitmapData.Stride,
-                        dst + y * rowBytes,
-                        rowBytes,
-                        Math.Min(bitmapData.Stride, rowBytes));
-                }
+                BgraRowCopyHelper.CopyRows(
+                    bitmapData.Scan0,
+                    bitmapData.Stride,
+                    skBitmap.GetPixels(),
+                    rowBytes,
+                    gdiBitmap.Width * 4,
+                    gdiBitmap.Height);
             }
 
             return skBitmap;

--- a/src/platform/XerahS.Platform.Windows/Recording/MediaFoundationEncoder.cs
+++ b/src/platform/XerahS.Platform.Windows/Recording/MediaFoundationEncoder.cs
@@ -26,6 +26,7 @@
 using Vortice.DXGI;
 using System.Runtime.InteropServices;
 using XerahS.RegionCapture.ScreenRecording;
+using XerahS.Platform.Windows.Capture;
 
 namespace XerahS.Platform.Windows.Recording;
 
@@ -125,6 +126,13 @@ public class MediaFoundationEncoder : IVideoEncoder
     private void CreateSinkWriter()
     {
         Core.Helpers.TroubleshootingHelper.Log("ScreenRecorder", "MF_ENCODER", "CreateSinkWriter() starting...");
+
+        if (_format?.Codec != VideoCodec.H264)
+        {
+            throw new PlatformNotSupportedException(
+                $"Media Foundation recording currently supports {VideoCodec.H264} only. " +
+                $"{_format?.Codec} must use the FFmpeg recording backend.");
+        }
         
         // Create attributes
         Core.Helpers.TroubleshootingHelper.Log("ScreenRecorder", "MF_ENCODER", "Calling MFCreateAttributes...");
@@ -350,40 +358,15 @@ public class MediaFoundationEncoder : IVideoEncoder
     private unsafe void CopyFrame(FrameData frame, IntPtr bufferPtr, int destStride)
     {
         int bytesPerRow = frame.Width * 4;
-        int srcStride = frame.Stride;
-
-        if (_applyVerticalFlip)
-        {
-            // [2026-01-10T14:37:00+08:00] Apply vertical flip only; prior 180° rotation fixed upside-down but left horizontal mirror.
-            byte* srcBase = (byte*)frame.DataPtr.ToPointer();
-            byte* dstBase = (byte*)bufferPtr.ToPointer();
-            int height = frame.Height;
-
-            for (int y = 0; y < height; y++)
-            {
-                byte* srcRow = srcBase + (height - 1 - y) * srcStride;
-                byte* dstRow = dstBase + y * destStride;
-                Buffer.MemoryCopy(srcRow, dstRow, destStride, bytesPerRow);
-            }
-        }
-        else
-        {
-            if (srcStride == destStride)
-            {
-                Buffer.MemoryCopy(frame.DataPtr.ToPointer(), bufferPtr.ToPointer(), destStride * frame.Height, destStride * frame.Height);
-                return;
-            }
-
-            byte* srcBase = (byte*)frame.DataPtr.ToPointer();
-            byte* dstBase = (byte*)bufferPtr.ToPointer();
-
-            for (int y = 0; y < frame.Height; y++)
-            {
-                byte* srcRow = srcBase + y * srcStride;
-                byte* dstRow = dstBase + y * destStride;
-                Buffer.MemoryCopy(srcRow, dstRow, destStride, bytesPerRow);
-            }
-        }
+        System.Diagnostics.Debug.Assert(frame.Stride >= bytesPerRow, "Frame stride must include a full pixel row.");
+        BgraRowCopyHelper.CopyRows(
+            frame.DataPtr,
+            frame.Stride,
+            bufferPtr,
+            destStride,
+            bytesPerRow,
+            frame.Height,
+            flipVertically: _applyVerticalFlip);
     }
 
     private void Cleanup()

--- a/src/platform/XerahS.Platform.Windows/WindowsModernCaptureService.cs
+++ b/src/platform/XerahS.Platform.Windows/WindowsModernCaptureService.cs
@@ -30,6 +30,7 @@ using Vortice.Direct3D;
 using Vortice.Direct3D11;
 using Vortice.DXGI;
 using System.Runtime.InteropServices;
+using XerahS.Platform.Windows.Capture;
 
 namespace XerahS.Platform.Windows
 {
@@ -533,18 +534,14 @@ namespace XerahS.Platform.Windows
             using var sourceBitmap = new SKBitmap(sourceWidth, sourceHeight, SKColorType.Bgra8888, SKAlphaType.Premul);
             var destPixels = sourceBitmap.GetPixels();
             int srcPitch = (int)dataBox.RowPitch;
-            int sourcePitch = sourceWidth * 4;
-
-            unsafe
-            {
-                for (int y = 0; y < sourceHeight; y++)
-                {
-                    IntPtr srcRow = IntPtr.Add(dataBox.DataPointer, y * srcPitch);
-                    IntPtr destRow = IntPtr.Add(destPixels, y * sourcePitch);
-
-                    Buffer.MemoryCopy((void*)srcRow, (void*)destRow, sourcePitch, sourcePitch);
-                }
-            }
+            int bytesPerRow = sourceWidth * 4;
+            BgraRowCopyHelper.CopyRows(
+                dataBox.DataPointer,
+                srcPitch,
+                destPixels,
+                bytesPerRow,
+                bytesPerRow,
+                sourceHeight);
 
             using SKBitmap bitmapToDraw = RotateBitmapForDesktop(sourceBitmap, rotation);
             var destRect = new SKRect(destX, destY, destX + destWidth, destY + destHeight);

--- a/tests/XerahS.Tests/Platform/Windows/BgraRowCopyHelperTests.cs
+++ b/tests/XerahS.Tests/Platform/Windows/BgraRowCopyHelperTests.cs
@@ -1,0 +1,145 @@
+#region License Information (GPL v3)
+
+/*
+    XerahS - The Avalonia UI implementation of ShareX
+    Copyright (c) 2007-2026 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using System.Runtime.InteropServices;
+using NUnit.Framework;
+using XerahS.Platform.Windows.Capture;
+
+namespace XerahS.Tests.Platform.Windows;
+
+[TestFixture]
+public class BgraRowCopyHelperTests
+{
+    [Test]
+    public void CopyRows_PaddedSourceStride_CopiesOnlyPixelBytes()
+    {
+        const int bytesPerRow = 8;
+        const int sourceStride = 16;
+        const int height = 2;
+
+        byte[] source =
+        [
+            1, 2, 3, 4, 5, 6, 7, 8, 200, 201, 202, 203, 204, 205, 206, 207,
+            9, 10, 11, 12, 13, 14, 15, 16, 210, 211, 212, 213, 214, 215, 216, 217
+        ];
+        byte[] destination = new byte[bytesPerRow * height];
+
+        IntPtr sourcePtr = Marshal.AllocHGlobal(source.Length);
+        IntPtr destinationPtr = Marshal.AllocHGlobal(destination.Length);
+
+        try
+        {
+            Marshal.Copy(source, 0, sourcePtr, source.Length);
+            BgraRowCopyHelper.CopyRows(sourcePtr, sourceStride, destinationPtr, bytesPerRow, bytesPerRow, height);
+            Marshal.Copy(destinationPtr, destination, 0, destination.Length);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(destinationPtr);
+            Marshal.FreeHGlobal(sourcePtr);
+        }
+
+        Assert.That(destination, Is.EqualTo(new byte[]
+        {
+            1, 2, 3, 4, 5, 6, 7, 8,
+            9, 10, 11, 12, 13, 14, 15, 16
+        }));
+    }
+
+    [Test]
+    public void CopyRows_FlipVertically_ReversesRowOrderWithoutUsingPadding()
+    {
+        const int bytesPerRow = 4;
+        const int sourceStride = 8;
+        const int height = 3;
+
+        byte[] source =
+        [
+            1, 2, 3, 4, 50, 51, 52, 53,
+            5, 6, 7, 8, 60, 61, 62, 63,
+            9, 10, 11, 12, 70, 71, 72, 73
+        ];
+        byte[] destination = new byte[bytesPerRow * height];
+
+        IntPtr sourcePtr = Marshal.AllocHGlobal(source.Length);
+        IntPtr destinationPtr = Marshal.AllocHGlobal(destination.Length);
+
+        try
+        {
+            Marshal.Copy(source, 0, sourcePtr, source.Length);
+            BgraRowCopyHelper.CopyRows(sourcePtr, sourceStride, destinationPtr, bytesPerRow, bytesPerRow, height, flipVertically: true);
+            Marshal.Copy(destinationPtr, destination, 0, destination.Length);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(destinationPtr);
+            Marshal.FreeHGlobal(sourcePtr);
+        }
+
+        Assert.That(destination, Is.EqualTo(new byte[]
+        {
+            9, 10, 11, 12,
+            5, 6, 7, 8,
+            1, 2, 3, 4
+        }));
+    }
+
+    [Test]
+    public void CopyRows_NegativeSourceStride_NormalizesToTopRow()
+    {
+        const int bytesPerRow = 4;
+        const int sourceStride = -8;
+        const int height = 2;
+
+        byte[] source =
+        [
+            1, 2, 3, 4, 101, 102, 103, 104,
+            5, 6, 7, 8, 105, 106, 107, 108
+        ];
+        byte[] destination = new byte[bytesPerRow * height];
+
+        IntPtr sourceBase = Marshal.AllocHGlobal(source.Length);
+        IntPtr destinationPtr = Marshal.AllocHGlobal(destination.Length);
+
+        try
+        {
+            Marshal.Copy(source, 0, sourceBase, source.Length);
+            IntPtr bottomRowPointer = IntPtr.Add(sourceBase, 8);
+            BgraRowCopyHelper.CopyRows(bottomRowPointer, sourceStride, destinationPtr, bytesPerRow, bytesPerRow, height);
+            Marshal.Copy(destinationPtr, destination, 0, destination.Length);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(destinationPtr);
+            Marshal.FreeHGlobal(sourceBase);
+        }
+
+        Assert.That(destination, Is.EqualTo(new byte[]
+        {
+            1, 2, 3, 4,
+            5, 6, 7, 8
+        }));
+    }
+}

--- a/tests/XerahS.Tests/RegionCapture/RecordingCodecSupportPolicyTests.cs
+++ b/tests/XerahS.Tests/RegionCapture/RecordingCodecSupportPolicyTests.cs
@@ -1,0 +1,75 @@
+#region License Information (GPL v3)
+
+/*
+    XerahS - The Avalonia UI implementation of ShareX
+    Copyright (c) 2007-2026 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using NUnit.Framework;
+using XerahS.RegionCapture.ScreenRecording;
+
+namespace XerahS.Tests.RegionCapture;
+
+[TestFixture]
+public class RecordingCodecSupportPolicyTests
+{
+    [Test]
+    public void RequiresFfmpegFallback_WindowsNonH264_ReturnsTrue()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(RecordingCodecSupportPolicy.RequiresFfmpegFallback(VideoCodec.HEVC, isWindows: true, isMacOS: false, isLinux: false), Is.True);
+            Assert.That(RecordingCodecSupportPolicy.RequiresFfmpegFallback(VideoCodec.VP9, isWindows: true, isMacOS: false, isLinux: false), Is.True);
+            Assert.That(RecordingCodecSupportPolicy.RequiresFfmpegFallback(VideoCodec.AV1, isWindows: true, isMacOS: false, isLinux: false), Is.True);
+            Assert.That(RecordingCodecSupportPolicy.RequiresFfmpegFallback(VideoCodec.H264, isWindows: true, isMacOS: false, isLinux: false), Is.False);
+        });
+    }
+
+    [Test]
+    public void GetSelectableCodecs_WindowsWithoutFfmpeg_ReturnsH264Only()
+    {
+        var codecs = RecordingCodecSupportPolicy.GetSelectableCodecs(
+            ffmpegAvailable: false,
+            isWindows: true,
+            isMacOS: false,
+            isLinux: false);
+
+        Assert.That(codecs, Is.EqualTo(new[] { VideoCodec.H264 }));
+    }
+
+    [Test]
+    public void GetSelectableCodecs_LinuxWithoutFfmpeg_KeepsAllCodecs()
+    {
+        var codecs = RecordingCodecSupportPolicy.GetSelectableCodecs(
+            ffmpegAvailable: false,
+            isWindows: false,
+            isMacOS: false,
+            isLinux: true);
+
+        Assert.That(codecs, Is.EqualTo(new[]
+        {
+            VideoCodec.H264,
+            VideoCodec.HEVC,
+            VideoCodec.VP9,
+            VideoCodec.AV1
+        }));
+    }
+}

--- a/tests/XerahS.Tests/RegionCapture/RegionCropperTests.cs
+++ b/tests/XerahS.Tests/RegionCapture/RegionCropperTests.cs
@@ -1,0 +1,119 @@
+#region License Information (GPL v3)
+
+/*
+    XerahS - The Avalonia UI implementation of ShareX
+    Copyright (c) 2007-2026 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using System.Drawing;
+using System.Runtime.InteropServices;
+using NUnit.Framework;
+using XerahS.RegionCapture.ScreenRecording;
+
+namespace XerahS.Tests.RegionCapture;
+
+[TestFixture]
+public class RegionCropperTests
+{
+    [Test]
+    public void CropFrame_PaddedStride_CopiesRequestedPixelsOnly()
+    {
+        const int width = 4;
+        const int height = 3;
+        const int stride = 20;
+
+        byte[] source =
+        [
+            1, 2, 3, 4,   5, 6, 7, 8,   9, 10, 11, 12,  13, 14, 15, 16,  90, 91, 92, 93,
+            17, 18, 19, 20,  21, 22, 23, 24,  25, 26, 27, 28,  29, 30, 31, 32,  94, 95, 96, 97,
+            33, 34, 35, 36,  37, 38, 39, 40,  41, 42, 43, 44,  45, 46, 47, 48,  98, 99, 100, 101
+        ];
+
+        IntPtr sourcePtr = Marshal.AllocHGlobal(source.Length);
+        Marshal.Copy(source, 0, sourcePtr, source.Length);
+
+        FrameData cropped = default;
+
+        try
+        {
+            var frame = new FrameData
+            {
+                DataPtr = sourcePtr,
+                Stride = stride,
+                Width = width,
+                Height = height,
+                Format = PixelFormat.Bgra32
+            };
+
+            cropped = RegionCropper.CropFrame(frame, new Rectangle(1, 1, 2, 2));
+
+            byte[] actual = new byte[cropped.Stride * cropped.Height];
+            Marshal.Copy(cropped.DataPtr, actual, 0, actual.Length);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(cropped.Stride, Is.EqualTo(8));
+                Assert.That(actual, Is.EqualTo(new byte[]
+                {
+                    21, 22, 23, 24, 25, 26, 27, 28,
+                    37, 38, 39, 40, 41, 42, 43, 44
+                }));
+            });
+        }
+        finally
+        {
+            if (cropped.DataPtr != IntPtr.Zero)
+            {
+                RegionCropper.FreeCroppedFrame(cropped);
+            }
+
+            Marshal.FreeHGlobal(sourcePtr);
+        }
+    }
+
+    [Test]
+    public void CropFrame_InvalidStride_Throws()
+    {
+        byte[] source = new byte[16];
+        IntPtr sourcePtr = Marshal.AllocHGlobal(source.Length);
+
+        try
+        {
+            Marshal.Copy(source, 0, sourcePtr, source.Length);
+            var frame = new FrameData
+            {
+                DataPtr = sourcePtr,
+                Stride = 12,
+                Width = 4,
+                Height = 1,
+                Format = PixelFormat.Bgra32
+            };
+
+            Assert.That(
+                () => RegionCropper.CropFrame(frame, new Rectangle(0, 0, 1, 1)),
+                Throws.ArgumentException.With.Message.Contains("stride"));
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(sourcePtr);
+        }
+    }
+}

--- a/tests/XerahS.Tests/XerahS.Tests.csproj
+++ b/tests/XerahS.Tests/XerahS.Tests.csproj
@@ -57,6 +57,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
+    <Compile Remove="Platform\Windows\BgraRowCopyHelperTests.cs" />
     <Compile Remove="Platform\Windows\WindowsClipboardImageHelperTests.cs" />
     <Compile Remove="Platform\Windows\WindowsScrollingCaptureServiceTests.cs" />
     <Compile Remove="RegionCapture\NativeWindowServiceTests.cs" />


### PR DESCRIPTION
This pull request introduces significant improvements to how video codecs are selected and handled in the screen recording workflow, particularly regarding native and FFmpeg-based encoding. The changes centralize codec support policy, improve user feedback in the UI, and strengthen pixel buffer handling for Windows capture strategies. These updates ensure that only supported codecs are selectable based on platform and FFmpeg availability, provide clear guidance to users, and improve the reliability of bitmap copying operations.

**Codec selection and support policy:**

- Introduced the `RecordingCodecSupportPolicy` class to centralize logic for determining which video codecs are available natively and which require FFmpeg fallback, with platform-specific handling. (`src/desktop/app/XerahS.RegionCapture/ScreenRecording/RecordingCodecSupportPolicy.cs`)
- Updated `RecordingViewModel` to use `RecordingCodecSupportPolicy` for determining available codecs, and to display a user-facing message when advanced codecs are unavailable due to missing FFmpeg. (`src/desktop/app/XerahS.UI/ViewModels/RecordingViewModel.cs`, `src/desktop/app/XerahS.UI/Views/RecordingView.axaml`) [[1]](diffhunk://#diff-a9f2310abcef33aaf78f889dcfcfd7afbc7e123b1cd2c092675508ace7eb1e87L126-R131) [[2]](diffhunk://#diff-a9f2310abcef33aaf78f889dcfcfd7afbc7e123b1cd2c092675508ace7eb1e87R119-R121) [[3]](diffhunk://#diff-a9f2310abcef33aaf78f889dcfcfd7afbc7e123b1cd2c092675508ace7eb1e87R531-R543) [[4]](diffhunk://#diff-b16c1d4c33302f73281c19d92e5f3859e0fac65ad82df5cf6986d572cd6716e7R133-R138)
- Added logic to ensure the selected codec is valid for the current environment, resetting to H.264 if necessary and updating the UI accordingly. (`src/desktop/app/XerahS.UI/ViewModels/RecordingViewModel.cs`)

**User interface and messaging:**

- Enhanced encoder information and usage notes to reflect the current codec support, providing clear instructions about FFmpeg requirements and platform capabilities. (`src/desktop/app/XerahS.UI/ViewModels/RecordingViewModel.cs`) [[1]](diffhunk://#diff-a9f2310abcef33aaf78f889dcfcfd7afbc7e123b1cd2c092675508ace7eb1e87L157-R169) [[2]](diffhunk://#diff-a9f2310abcef33aaf78f889dcfcfd7afbc7e123b1cd2c092675508ace7eb1e87L205-R225)
- Added a dedicated UI element to display codec availability messages, improving user awareness of codec restrictions. (`src/desktop/app/XerahS.UI/Views/RecordingView.axaml`)

**Screen recording backend and reliability:**

- Enforced that only H.264 is supported by the Media Foundation encoder, throwing an explicit exception if an unsupported codec is selected, and ensuring fallback to FFmpeg for other codecs. (`src/platform/XerahS.Platform.Windows/Recording/MediaFoundationEncoder.cs`, `src/desktop/core/XerahS.Core/Managers/ScreenRecordingManager.cs`) [[1]](diffhunk://#diff-3ea6dfb9d76195e39419c28b2af70bfefd0094fedcf0e053850a6b6dbd6ad463R130-R136) [[2]](diffhunk://#diff-4a446692dca6a50e6a7ed68e77a58954acf6a3d717464e332831f10eb2755167R474-R482)
- Improved stride validation and error handling in frame cropping and pixel buffer management, preventing invalid memory access when source stride is too small. (`src/desktop/app/XerahS.RegionCapture/ScreenRecording/RegionCropper.cs`, `src/desktop/app/XerahS.RegionCapture/ScreenRecording/RecordingModels.cs`) [[1]](diffhunk://#diff-715c089ff058ee184e45ab65ca020765c89e9b7de54a863545cf95bed8785a4dR69-R75) [[2]](diffhunk://#diff-a0af9a3ba5bd224047d61d2499966199cc74764e3b01891e28d7a1850b73133eL134-R138)

**Windows capture performance and correctness:**

- Added the `BgraRowCopyHelper` utility for robust and efficient copying of BGRA pixel rows, handling stride and optional vertical flipping, and replaced manual row copying logic in both DXGI and GDI capture strategies with this helper. (`src/platform/XerahS.Platform.Windows/Capture/BgraRowCopyHelper.cs`, `src/platform/XerahS.Platform.Windows/Capture/DxgiCaptureStrategy.cs`, `src/platform/XerahS.Platform.Windows/Capture/GdiCaptureStrategy.cs`) [[1]](diffhunk://#diff-9d5126fe489b37c15456ad470cfe094b443f47a5e150370a3d1ddfd8704dc2cdR1-R63) [[2]](diffhunk://#diff-c97ed98e14958e38e8e1fbc9cb71c87b21b03f805678100a783223f4a9b2fb56L242-R249) [[3]](diffhunk://#diff-d00cbea49a7a631b265aa0b7ba9858727b65432c7ff5481e244cc1adfde0c9e7L151-R158)

**Other:**

- Bumped the application version to `0.22.2`. (`Directory.Build.props`)
- Updated the `ShareX.VideoEditor` submodule. (`ShareX.VideoEditor`)