### PR TITLE
Fix URL path encoding breaking FTP/SFTP result URLs

### DIFF
--- a/src/desktop/core/XerahS.Common/Helpers/URLHelpers.cs
+++ b/src/desktop/core/XerahS.Common/Helpers/URLHelpers.cs
@@ -369,9 +369,7 @@ namespace XerahS.Common
         {
             if (replaceSpace) url = url.Replace(' ', '_');
 
-            // System.Web.HttpUtility.UrlPathEncode is obsolete and not in .NET Core usually
-            // We can emulate it or use WebUtility
-            return Uri.EscapeDataString(url);
+            return URLEncode(url, isPath: true);
         }
 
         public static void OpenURL(string url)


### PR DESCRIPTION
GetValidURL() was using Uri.EscapeDataString() which encodes all reserved characters including path separators (/ → %2F). This caused GetHttpHomePath() to return a fully-encoded string (e.g. "winteris.moe%2Fshare%2F") which GetUriPath() then stuffed entirely into the UriBuilder.Host field, crashing with "Invalid URI: The hostname could not be parsed."

Replace with URLEncode(isPath: true) which preserves path-safe characters like / : @ while still encoding unsafe characters. This matches the behavior of the now-obsolete HttpUtility.UrlPathEncode that the original ShareX code used.