### PR TITLE
Fix SFTP upload speed by replacing SftpFileStream + TransferData() with SftpClient.UploadFile()

### DIFF
--- a/src/desktop/core/XerahS.Uploaders/Helpers/ProgressManager.cs
+++ b/src/desktop/core/XerahS.Uploaders/Helpers/ProgressManager.cs
@@ -73,6 +73,7 @@ namespace XerahS.Uploaders
 
             if (Position >= Length)
             {
+                Position = Length;
                 startTimer.Stop();
 
                 return true;

--- a/src/desktop/plugins/Ftp.Plugin/FtpUploader.cs
+++ b/src/desktop/plugins/Ftp.Plugin/FtpUploader.cs
@@ -31,7 +31,6 @@ using FluentFTP;
 using FluentFTP.Exceptions;
 using Renci.SshNet;
 using Renci.SshNet.Common;
-using Renci.SshNet.Sftp;
 using XerahS.Common;
 using XerahS.Uploaders;
 using XerahS.Uploaders.FileUploaders;
@@ -250,10 +249,41 @@ public sealed class FtpUploader : FileUploader, IDisposable
     private bool UploadSftpInternal(Stream stream, string remotePath)
     {
         if (_sftpClient == null || !_sftpClient.IsConnected) return false;
-        using (SftpFileStream remoteStream = _sftpClient.Create(remotePath))
+
+        long fileSize = stream.CanSeek ? stream.Length : -1;
+        ProgressManager? progress = fileSize > 0 ? new ProgressManager(fileSize) : null;
+        ulong lastUploadedBytes = 0;
+        object progressLock = new object();
+
+        // We have to use a lock here because UploadFile fires progress callbacks concurrently from multiple threads.
+        _sftpClient.UploadFile(stream, remotePath, canOverride: true, uploadedBytes =>
         {
-            return TransferData(stream, remoteStream);
-        }
+            if (StopUploadRequested)
+            {
+                _sftpClient.Disconnect();
+                return;
+            }
+
+            if (AllowReportProgress && progress != null)
+            {
+                lock (progressLock)
+                {
+                    long delta = (long)(uploadedBytes - lastUploadedBytes);
+
+                    if (delta > 0)
+                    {
+                        lastUploadedBytes = uploadedBytes;
+
+                        if (progress.UpdateProgress(delta))
+                        {
+                            OnProgressChanged(progress);
+                        }
+                    }
+                }
+            }
+        });
+
+        return !StopUploadRequested;
     }
 
     private void CreateMultiDirectorySftp(string path)


### PR DESCRIPTION
SSH.NET's [SftpFileStream](https://sshnet.github.io/SSH.NET/api/Renci.SshNet.Sftp.SftpFileStream.html) synchronously blocks waiting for an ACK for each packet written with SSH_FXP_WRITE, making throughput entirely latency-bound:

  ~32KB per packet / RTT = max throughput
  e.g. 32KB / 50ms RTT ≈ 640 KB/s regardless of available bandwidth

[SftpClient](https://sshnet.github.io/SSH.NET/api/Renci.SshNet.SftpClient.html).UploadFile() sends multiple write requests concurrently without waiting for individual ACKs, leading to MUCH faster transfer speed. In my case I went from ~700KB/s to ~30MB/s (!!!).

Because UploadFile() dispatches its progress callback from thread pool threads (one per in-flight write response), the callback is synchronized with a lock to prevent ProgressManager from crashing.

ProgressManager.UpdateProgress() now also clamps Position to Length to guard against Percentage exceeding 100%, which would crash the progress bar control due to callbacks potentially firing out of order.

This is the same issue as existed in the original ShareX: https://github.com/ShareX/ShareX/pull/8478